### PR TITLE
advise when encoding is not supported.

### DIFF
--- a/src/ioformats/nrrd.jl
+++ b/src/ioformats/nrrd.jl
@@ -89,6 +89,8 @@ function imread{S<:IO}(stream::S, ::Type{Images.NRRDFile})
                 end
             end
         end
+    else
+      error("\"", header["encoding"], "\" encoding not supported.")
     end
     if haskey(header, "kinds")
         kinds = split(header["kinds"], " ")


### PR DESCRIPTION
simple error reporting when encoding is not supported.. if you try to read in a nrrd with gzip encoding julia gives you some very non-obvious errors (non-obvious to a julia newb).
