### PR TITLE
Fix #53 and some

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -158,9 +158,9 @@ function imwrite(img, filename::String; kwargs...)
 end
 
 function imwrite{T<:ImageFileType}(img, filename::String, ::Type{T}; kwargs...)
-    s = open(filename, "w")
-    imwrite(img, s, T; kwargs...)
-    close(s)
+    open(filename, "w") do s
+        imwrite(img, s, T; kwargs...)
+    end
 end
 
 function writemime(stream::IO, ::MIME"image/png", img::AbstractImage; scalei = scaleinfo_uint(img))
@@ -496,8 +496,9 @@ function imread{S<:IO}(stream::S, ::Type{PBMBinary})
 end
 
 function imwrite(img, filename::String, ::Type{PPMBinary})
-    stream = open(filename, "w")
-    imwrite(img, stream, PPMBinary)
+    open(filename, "w") do stream
+        imwrite(img, stream, PPMBinary)
+    end
 end
 
 function imwrite(img, s::IO, ::Type{PPMBinary})
@@ -519,7 +520,6 @@ function imwrite(img, s::IO, ::Type{PPMBinary})
     scalei = scaleinfo(T, img)
     write(s, "$w $h\n$mx\n")
     writecolor(s, img, scalei)
-    close(s)
 end
 
 # ## PNG ##

--- a/src/ioformats/dummy.jl
+++ b/src/ioformats/dummy.jl
@@ -6,7 +6,7 @@ function imread{S<:IO}(stream::S, ::Type{Images.Dummy})
 end
 
 function imwrite(img, filename::String, ::Type{Images.Dummy})
-    stream = open(filename, "w")
-    println(stream, "Dummy Image")
-    close(stream)
+    open(filename, "w") do stream
+        println(stream, "Dummy Image")
+    end
 end


### PR DESCRIPTION
Finally figured it out. `imread(::String)` wasn't closing the stream it opened! I verified my solution (4934a81) using `lsof -c julia` and all file handles are indeed closed.

In the same run, I:
- changed all `stream = open(...)` to `open(...) do stream` which should be safer when exceptions occur.
- made `imwrite(.., ::String, ::Type{PPMBinary})` close the file it opens, and `imwrite(.., ::IO, ::Type{PPMBinary})` not close it, since it hasn't opened it and the caller doesn't expect that to happen!
- removed unnecessary `magicbuf` and allocate id large enough instead of growing it.

I think `src/ioformats/nrrd.jl` lines 57 and 59 do open streams which are never closed. I didn't touch that code since I have no clue about that fileformat and thus wouldn't even be able to test it. Just letting you know.
