### PR TITLE
Add alias for libMagickWand on Fedora

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,7 @@ using BinDeps
 @BinDeps.setup
 
 @linux_only begin
-    libwand = library_dependency("libMagickWand")
+    libwand = library_dependency("libMagickWand", aliases=["libMagickWand", "libMagickWand-6.Q16.so.1"])
     provides(AptGet, "libmagickwand4", libwand)
     provides(Yum, "ImageMagick", libwand)
 end


### PR DESCRIPTION
Another small fix to make the install work on Fedora.
