### PR TITLE
Make image data contiguous before passing it to libmagickwand.

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -252,10 +252,14 @@ function image2wand(img, scalei)
     end
     n = size(imgw, 3+have_color)
     wand = LibMagick.MagickWand()
-    LibMagick.constituteimage(to_explicit(data(imgw)), wand, colorspace(img))
+    LibMagick.constituteimage(to_explicit(to_contiguous(data(imgw))), wand, colorspace(img))
     LibMagick.resetiterator(wand)
     wand
 end
+
+# Make the data contiguous in memory, this is necessary for imagemagick since it doesn't handle stride.
+to_contiguous(A::AbstractArray) = A
+to_contiguous(A::SubArray) = copy(A)
 
 to_explicit(A::AbstractArray) = A
 to_explicit(A::AbstractArray{RGB8}) = reinterpret(Uint8, A, tuple(3, size(A)...))


### PR DESCRIPTION
This fixes #97

and also a typo, I didn't squash because it's two different things.

By the way, note that [the line computing `n`](https://github.com/timholy/Images.jl/blob/4a98/src%2Fio.jl#L253) is unnecessary, as `n` is unused. I guess you wanted to use this to write a stack of slices of a 3D image/video into the wand but never got around to it? Thus I left it in there.
