### PR TITLE
Add more aliases and the libmagickwand5 Apt package

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,9 +6,12 @@ using BinDeps
     libnames = ["libMagickWand"]
     suffixes = ["", "-Q16", "-6.Q16", "-Q8"]
     options = ["", "HDRI"]
-    aliases = vec(libnames.*transpose(suffixes).*reshape(options,(1,1,length(options))))
+    extensions = ["", ".so.4", ".so.5"]
+    aliases = vec(libnames.*transpose(suffixes).*reshape(options,(1,1,length(options))).*
+        reshape(extensions,(1,1,1,length(extensions))))
     libwand = library_dependency("libMagickWand", aliases=aliases)
     provides(AptGet, "libmagickwand4", libwand)
+    provides(AptGet, "libmagickwand5", libwand)
     provides(Yum, "ImageMagick", libwand)
 end
 


### PR DESCRIPTION
I'm not quite happy with the fact that this is necessary. There is also the problem that BinDeps doesn't know which of the two AptGet packages actually provided the library. Not a huge problem, but I would still like not to have it. The other thing that would be nice is if we could just parse all the libraries that the apt-package contains and see which lone of them start with "libMagickWand" and just use those. Anyway this works for now. cc @staticfloat
