### PR TITLE
Missing quality argument for image2wand

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -192,7 +192,7 @@ function _writemime(stream::IO, ::MIME"image/png", img::AbstractImage; scalei=sc
     if eltype(A) != eltype(img)
         A = truncround(eltype(img), A)
     end
-    wand = image2wand(share(img, A), scalei)
+    wand = image2wand(share(img, A), scalei, nothing)
 #     LibMagick.setimagecompression(wand, LibMagick.NoCompression)
     blob = LibMagick.getblob(wand, "png")
     write(stream, blob)


### PR DESCRIPTION
_writemime was formerly calling image2wand with the third argument missing.
This breaks displaying inline images in IJulia in v0.3.2 of Images.jl
