### PR TITLE
Move the libwand version check to build time

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -69,3 +69,14 @@ end
 end
 
 @BinDeps.install [:libwand => :libwand]
+
+# Save the library version; by checking this now, we avoid a runtime dependency on libwand
+# See https://github.com/timholy/Images.jl/issues/184#issuecomment-55643225
+module CheckVersion
+include("deps.jl")
+p = ccall((:MagickQueryConfigureOption, libwand), Ptr{Uint8}, (Ptr{Uint8},), "LIB_VERSION_NUMBER")
+vstr = string("v\"", join(split(bytestring(p), ',')[1:3], '.'), "\"")
+open("deps.jl", "a") do file
+    write(file, "const libversion = $vstr\n")
+end
+end

--- a/src/ioformats/libmagickwand.jl
+++ b/src/ioformats/libmagickwand.jl
@@ -36,9 +36,6 @@ function init()
     global libwand
     if have_imagemagick
         eval(:(ccall((:MagickWandGenesis, $libwand), Void, ())))
-        vstr = queryoption("LIB_VERSION_NUMBER")
-        vstr = join(split(vstr, ',')[1:3], '.')
-        eval(:(const libversion = @v_str $vstr))
     else
         warn("ImageMagick utilities not found. Install for more file format support.")
     end


### PR DESCRIPTION
This should prevent the segfault reported in #184 

@staticfloat & @Keno, I didn't find a way to get BinDeps to do this, but I could have easily missed a better way.
