### PR TITLE
Use Ufixed8 for ScaleMinMax in sc(...)

### DIFF
--- a/src/map.jl
+++ b/src/map.jl
@@ -478,8 +478,8 @@ uint32color!{T,N,N1}(buf::Array{Uint32,N}, img::AbstractImageDirect{T,N1}, mi::M
     map!(mi, buf, img, TypeConst{colordim(img)})
 
 
-sc(img::AbstractArray) = map(ScaleMinMax(img), img)
-sc(img::AbstractArray, mn::Real, mx::Real) = map(ScaleMinMax(img, mn, mx), img)
+sc(img::AbstractArray) = map(ScaleMinMax(Ufixed8, img), img)
+sc(img::AbstractArray, mn::Real, mx::Real) = map(ScaleMinMax(Ufixed8, img, mn, mx), img)
 
 convert{T}(::Type{AbstractImageDirect{T,2}},M::Tridiagonal) = error("Not defined") # prevent ambiguity warning
 

--- a/test/map.jl
+++ b/test/map.jl
@@ -189,6 +189,12 @@ A = reinterpret(Ufixed8, [uint8(1:24)], (3, 2, 4))
 img = reinterpret(RGB{Ufixed8}, A, (2,4))
 @test separate(img) == permutedims(A, (2,3,1))
 
+# sc
+arr = zeros(4,4)
+arr[2,2] = 0.5
+@assert sc(arr)[2,2] == 0xffuf8
+@assert sc(arr, 0.0, 0.75)[2,2] == 0xaauf8
+
 # color conversion
 gray = linspace(0.0,1.0,5) # a 1-dimensional image
 gray8 = iround(Uint8, 255*gray)


### PR DESCRIPTION
Before this change:

``` julia
julia> typeof(f)
Array{Float64,2}

julia> sc(f)
ERROR: `ScaleMinMax{To,From,S<:FloatingPoint}` has no method matching ScaleMinMax{To,From,S<:FloatingPoint}(::Array{Float64,2})
 in sc at /Users/kevin/.julia/v0.3/Images/src/map.jl:481

julia> sc(f, 0, 0.7)
WARNING: (ScaleMinMax{T<:Real})(img::AbstractArray{T},mn,mx) is deprecated, use ScaleMinMax(Ufixed8,img,mn,mx) instead.
 in sc at /Users/kevin/.julia/v0.3/Images/src/map.jl:482
4x4 Array{UfixedBase{Uint8,8},2}:
 0.0  0.0    0.0  0.0
 0.0  0.714  0.0  0.0
 0.0  0.0    0.0  0.0
 0.0  0.0    0.0  0.0
```

After:

``` julia
julia> arr[2,2] = 0.5
0.5

julia> sc(arr)
4x4 Array{UfixedBase{Uint8,8},2}:
 0.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0
 0.0  0.0  0.0  0.0
 0.0  0.0  0.0  0.0

julia> sc(arr, 0.0, 0.75)[2,2]
Ufixed8(0.667)
```

`sc` isn't actually documented, so it's unclear to me if this should be merged, or if `sc` should simply go away...
