### PR TITLE
Support for imresize on color images

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1362,28 +1362,55 @@ restrict_size(len::Integer) = isodd(len) ? (len+1)>>1 : (len>>1)+1
 
 ## imresize
 function imresize!(resized, original)
-    assert2d(original)
-    scale1 = (size(original,1)-1)/(size(resized,1)-0.999f0)
-    scale2 = (size(original,2)-1)/(size(resized,2)-0.999f0)
-    for jr = 0:size(resized,2)-1
-        jo = scale2*jr
-        ijo = trunc(Int, jo)
-        fjo = jo - oftype(jo, ijo)
-        @inbounds for ir = 0:size(resized,1)-1
-            io = scale1*ir
-            iio = trunc(Int, io)
-            fio = io - oftype(io, iio)
-            tmp = (1-fio)*((1-fjo)*original[iio+1,ijo+1] +
-                           fjo*original[iio+1,ijo+2]) +
-                  + fio*((1-fjo)*original[iio+2,ijo+1] +
-                         fjo*original[iio+2,ijo+2])
-            resized[ir+1,jr+1] = convertsafely(eltype(resized), tmp)
-        end
+  assert2d(original)
+  if length(size(resized)) < length(size(original))
+    error("Number of output dimensions must not be smaller than number of
+    dimensions of original image.")
+  end
+  if colordim(original) > 0
+    assert_colordim_third(original)
+    csize = size(original,colordim(original))
+  else
+    csize = 1
+  end
+
+  scale1 = (size(original,1)-1)/(size(resized,1)-0.999f0)
+  scale2 = (size(original,2)-1)/(size(resized,2)-0.999f0)
+  for jr = 0:size(resized,2)-1
+    jo = scale2*jr
+    ijo = trunc(Int, jo)
+    fjo = jo - oftype(jo, ijo)
+    @inbounds for ir = 0:size(resized,1)-1
+      io = scale1*ir
+      iio = trunc(Int, io)
+      fio = io - oftype(io, iio)
+      for cr = 1:csize
+        tmp = (1-fio)*((1-fjo)*original[iio+1,ijo+1,cr] +
+        fjo*original[iio+1,ijo+2,cr]) +
+        + fio*((1-fjo)*original[iio+2,ijo+1,cr] +
+        fjo*original[iio+2,ijo+2,cr])
+        resized[ir+1,jr+1,cr] = convertsafely(eltype(resized), tmp)
+      end
     end
-    resized
+  end
+  resized
 end
 
-imresize(original, new_size) = size(original) == new_size ? copy!(similar(original), original) : imresize!(similar(original, new_size), original)
+function imresize(original, new_size)
+  if new_size == size(original) ||
+     new_size == size_spatial(original) && colordim(original) != 0
+     return copy!(similar(original), original)
+  elseif colordim(original) != 0 &&
+    length(new_size) >= length(size(original)) &&
+    new_size[colordim(original)] != size(original)[colordim(original)]
+    error("Resizing along color dimension not supported")
+  elseif colordim(original) != 0
+      new_size_ = (new_size[1],new_size[2],size(original,3))
+      return imresize!(similar(original, new_size_), original)
+  else
+      return imresize!(similar(original, new_size), original)
+  end
+end
 
 convertsafely{T<:AbstractFloat}(::Type{T}, val) = convert(T, val)
 convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)

--- a/src/core.jl
+++ b/src/core.jl
@@ -1173,6 +1173,26 @@ function assert_timedim_last(img::AbstractArray)
 end
 
 """
+`assert_colordim_third(img)` triggers an error if the image does not have color
+encoded in the third dimension.
+"""
+function assert_colordim_third(img::AbstractArray)
+  if colordim(img) != 3
+    error("Color is not encoded in the third dimension")
+  end
+end
+
+"""
+`assert_same_size(img1,img2)` triggers an error if both images are not of the
+same size.
+"""
+function assert_same_size(img1::AbstractArray,img2::AbstractArray)
+  if size(img1) != size(img2)
+    error("Images are not of same size")
+  end
+end
+
+"""
 `tf = isyfirst(img)` tests whether the first spatial dimension is `"y"`.
 
 See also: `isxfirst`, `assert_yfirst`.

--- a/src/core.jl
+++ b/src/core.jl
@@ -1183,16 +1183,6 @@ function assert_colordim_third(img::AbstractArray)
 end
 
 """
-`assert_same_size(img1,img2)` triggers an error if both images are not of the
-same size.
-"""
-function assert_same_size(img1::AbstractArray,img2::AbstractArray)
-  if size(img1) != size(img2)
-    error("Images are not of same size")
-  end
-end
-
-"""
 `tf = isyfirst(img)` tests whether the first spatial dimension is `"y"`.
 
 See also: `isxfirst`, `assert_yfirst`.


### PR DESCRIPTION
My humble attempt to make imresize work on color images.

For an RGB image, b=imresize(a,(new_x, new_y)) does the same as b=imresize(a,(new_x, new_y, 3)). However, if the size of the output color dimension is different from the size of the input color dimension, an error is thrown. For example, the following does not work for the above example: b=imresize(a,(new_x, new_y, 2))
