### PR TITLE
Another implementation of bwdist (feature_transform/euclidean_distance_transform)

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -65,6 +65,7 @@ include("edge.jl")
 include("showmime.jl")
 include("corner.jl")
 include("distances.jl")
+include("bwdist.jl")
 include("deprecated.jl")
 
 export # types
@@ -157,6 +158,7 @@ export # types
     imgaussiannoise,
     imlineardiffusion,
     imROF,
+    bwdist,
 
     #Exposure
     complement,

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -66,6 +66,7 @@ include("showmime.jl")
 include("corner.jl")
 include("distances.jl")
 include("bwdist.jl")
+using .FeatureTransform
 include("deprecated.jl")
 
 export # types
@@ -158,7 +159,8 @@ export # types
     imgaussiannoise,
     imlineardiffusion,
     imROF,
-    bwdist,
+    feature_transform,
+    distance_transform,
 
     #Exposure
     complement,
@@ -233,7 +235,7 @@ Algorithms:
     - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`, `canny`
     - Corner detection: `imcorner`, `harris`, `shi_tomasi`, `kitchen_rosenfeld`, `meancovs`, `gammacovs`, `fastcorners`
     - Blob detection: `blob_LoG`, `findlocalmaxima`, `findlocalminima`
-    - Morphological operations: `dilate`, `erode`, `closing`, `opening`, `tophat`, `bothat`, `morphogradient`, `morpholaplace`
+    - Morphological operations: `dilate`, `erode`, `closing`, `opening`, `tophat`, `bothat`, `morphogradient`, `morpholaplace`, `feature_transform`, `distance_transform`
     - Connected components: `label_components`, `component_boxes`, `component_lengths`, `component_indices`, `component_subscripts`, `component_centroids`
     - Interpolation: `bilinear_interpolation`
 

--- a/src/bwdist.jl
+++ b/src/bwdist.jl
@@ -1,0 +1,156 @@
+using Base.Cartesian
+
+# A function to permute a tuple of subscripts given a
+# permutation vector
+function permutesubs(subs::(Int...),perm::Vector{Int})
+    n = length(subs)
+    ntuple(n,x->subs[perm[x]])
+end
+
+# A function to both permute the dimensions of an array and
+# those of the linear indices stored in that array
+function permutedimsubs{N}(F::Array{Int,N},perm::Vector{Int})
+    B = permutedims(F,perm)
+    for i in 1:length(B)
+        B[i] = B[i] == 0 ? 0 : sub2ind(size(B),permutesubs(ind2sub(size(F),B[i]),perm)...)
+    end
+    return B
+end
+
+# A Cartesian macro that we'll need
+# We need to be able to generate a vector
+# the same way ntuple works
+macro nvect(N,ex)
+    _nvect(N,ex)
+end
+
+function _nvect(N::Int,ex)
+    vars = [Base.Cartesian.inlineanonymous(ex,i) for i = 1:N]
+    Expr(:escape, Expr(:vcat,vars...))
+end
+
+# Relevant distance functions copied from Distance.jl
+function get_common_len(a::AbstractVector, b::AbstractVector)
+    n = length(a)
+    length(b) == n || throw(DimensionMismatch("The lengths of a and b must match."))
+    return n
+end
+
+function sumsqdiff(a::AbstractVector, b::AbstractVector)
+    n = get_common_len(a, b)::Int
+    s = 0.
+    for i = 1:n
+        @inbounds s += abs2(a[i] - b[i])
+    end
+    s
+end
+
+sqeuclidean(a::AbstractVector, b::AbstractVector) = sumsqdiff(a,b)
+euclidean(a::AbstractVector,b::AbstractVector) = sqrt(sumsqdiff(a,b))
+
+# Be careful with this: you really need an Array of 0s and 1s
+bwdist(I::AbstractArray{Real}) = bwdist(convert(Bool,I))
+# bwdist: call this one!
+@ngenerate N (Array{Int},Array{Int}) function bwdist{N}(I::AbstractArray{Bool,N})
+    F = zeros(Int,size(I))
+    _computeft!(F,I)
+    d = [1:N]
+    for i in d
+        _voronoift!(F,I)
+        F = permutedimsubs(F,circshift(d,1))
+    end
+    D = zeros(Int,size(F))
+    @nexprs N d->(stride_d = strides(F)[d])
+    @nloops N i F begin
+        x = 1
+        (@nexprs N j->(x+=(i_j-1)*stride_j))
+        (@nref N D i) = sqeuclidean((@nref N F i),x,size(F))
+    end
+    return (F,D)
+end
+
+# Generate F_0 in the parlance of Maurer et al. 2003
+@ngenerate N typeof(F) function _computeft!{N}(F::Array{Int,N},I::AbstractArray{Bool,N})
+    @nexprs N d->(stride_d = strides(F)[d])
+    @nloops N i I begin
+        ind = 1
+        (@nref N F i) = (@nref N I i) ? (@nexprs N d->(ind+=(i_d-1)*stride_d)) : 0
+    end
+end
+
+# Compute the partial Voronoi diagram along the first dimension of F 
+# following Maurer et al. 2003
+@ngenerate N typeof(F) function _voronoift!{N}(F::Array{Int,N},I::AbstractArray{Bool,N})
+    @nexprs N d->(stride_d = strides(F)[d])
+    @nloops N d j->(j==1?0:1:size(F,j)) begin
+        Fstar = (@nref N F j->(j==1?(:):d_j))
+        l = 0
+        g = zeros(Int,length(Fstar)+1)
+        for i in 1:size(Fstar,1)
+            f = Fstar[i]
+            if f != 0
+                if l < 2
+                    l += 1
+                    g[l] = f
+                else
+                    while l>=2 && removeft2(g[l-1],g[l],f,d_2,size(F))
+                        l -= 1
+                    end
+                    l += 1
+                    g[l] = f
+                end
+            end
+        end
+        n_s = l
+        if n_s == 0
+        else            
+            l = 1
+            for d_1 in 1:length(Fstar)
+                # This makes a vector x containing the appropriate subscripts
+                # x = @nvect N (j->(j==1)?i:d_j)
+                # We now want it to make x a linear index in F; (i,d_2,d_3...)
+                # sub2ind(size(F),(@ntuple N j->(j==1?i:d_j))...)
+                # Or the Cartesianier way:
+                x = 1
+                (@nexprs N j->(x+=(d_j-1)*stride_j))
+                while l<n_s && (euclidean(x,g[l],size(F))>euclidean(x,g[l+1],size(F)))
+                    l += 1
+                end
+                (@nref N F d)= g[l]
+            end
+        end
+    end
+end
+
+# Calculate whether we should remove a feature pixel from the Voronoi diagram
+function removeft2(u::Int,v::Int,w::Int,r::Int,dims)
+    u1 = ind2sub(dims,u)[1]
+    v1 = ind2sub(dims,v)[1]
+    w1 = ind2sub(dims,w)[1]
+    a = v1-u1
+    b = w1-v1
+    c = a+b
+    c*distance2(v,r,dims)-b*distance2(u,r,dims)-a*distance2(w,r,dims)-a*b*c > 0
+end
+
+# Squared Euclidean distance from a linear index to a row index given by i
+function distance2(u::Int,r::Int,dims)
+    u2 = ind2sub(dims,u)[2]
+    (u2 - r)^2
+end
+
+# Squared Euclidean Distance between linear indices
+function sqeuclidean(x::Int,g::Int,dims)
+    x_subs = ind2sub(dims,x)
+    g_subs = ind2sub(dims,g)
+    s = 0
+    for i in 1:length(dims)
+        s += (x_subs[i]-g_subs[i])^2
+    end
+    return s
+end
+
+# Euclidean distance between linear indices
+euclidean(x::Int,g::Int,dims) = sqrt(sqeuclidean(x,g,dims))
+
+

--- a/test/bwdist.jl
+++ b/test/bwdist.jl
@@ -1,0 +1,99 @@
+using Base.Test, Images
+
+@testset "bwdist" begin
+    @testset "Square Images" begin
+        # (1)
+        A = [true false; false true]
+        (F, D) = bwdist(A)
+        @test F == [1 1; 1 4]
+        @test D == [0 1; 1 0]
+
+        # (2)
+        A = [true true; false true]
+        (F, D) = bwdist(A)
+        @test F == [1 3; 1 4]
+        @test D == [0 0; 1 0]
+
+        # (3)
+        A = [false false; false true]
+        (F, D) = bwdist(A)
+        @test F == [4 4; 4 4]
+        @test isapprox(D, [1.41421 1.0; 1.0 0.0], rtol=0.01)
+
+        # (4)
+        A = [true false true; false true false; true true false]
+        (F, D) = bwdist(A)
+        @test F == [1 1 7; 1 5 5; 3 6 6]
+        @test D == [0 1 0; 1 0 1; 0 0 1]
+
+        # (5)
+        A = [false false true; true true false; true true true]
+        (F, D) = bwdist(A)
+        @test F == [2 5 7; 2 5 5; 3 6 9]
+        @test D == [1 1 0; 0 0 1; 0 0 0]
+
+        # (6)
+        A = [true false true true; false true false false; false true true false; true false false false]
+        (F, D) = bwdist(A)
+        @test F == [1 1 9 13; 1 6 6 13; 4 7 11 11; 4 4 11 11]
+        @test isapprox(D, [0.0 1.0 0.0 0.0; 1.0 0.0 1.0 1.0; 1.0 0.0 0.0 1.0; 0.0 1.0 1.0 1.41421], rtol=0.01)
+    end
+
+    @testset "Rectangular Images" begin
+        # (1)
+        A = [true false true; false true false]
+        (F, D) = bwdist(A)
+        @test F == [1 1 5; 1 4 4]
+        @test D == [0 1 0; 1 0 1]
+
+        # (2)
+        A = [true false; false false; false true]
+        (F, D) = bwdist(A)
+        @test F == [1 1; 1 6; 6 6]
+        @test D == [0 1; 1 1; 1 0]
+
+        # (3)
+        A = [true false false; true false false; false true true; true true true; false true false]
+        (F, D) = bwdist(A)
+        @test F == [1 1 1; 2 2 13; 2 8 13; 4 9 14; 4 10 10]
+        @test D == [0.0 1.0 2.0; 0.0 1.0 1.0; 1.0 0.0 0.0; 0.0 0.0 0.0; 1.0 0.0 1.0]
+    end
+
+    @testset "Corner Case Images" begin
+        # (1)
+        A = [false]
+        (F, D) = bwdist(A)
+        @test F == [0]
+        @test D == [1]
+
+        # (2)
+        A = [true]
+        (F, D) = bwdist(A)
+        @test F == [1]
+        @test D == [0]
+
+        # (3)
+        A = [true false]
+        (F, D) = bwdist(A)
+        @test F == [1 1]
+        @test D == [0 1]
+
+        # (4)
+        A = [false; false]
+        (F, D) = bwdist(A)
+        @test F == [0; 0]
+        @test D == [1.0; 2.0]
+
+        # (5)
+        A = [true; true]
+        (F, D) = bwdist(A)
+        @test F == [1; 2]
+        @test D == [0; 0]
+
+        # (6)
+        A = [true; true; false]
+        (F, D) = bwdist(A)
+        @test F == [1; 2; 2]
+        @test D == [0; 0; 1]
+    end
+end

--- a/test/bwdist.jl
+++ b/test/bwdist.jl
@@ -1,99 +1,159 @@
 using Base.Test, Images
 
 @testset "bwdist" begin
+    ind2cart(F) = map(i->CartesianIndex(ind2sub(indices(F), i)), F)
     @testset "Square Images" begin
         # (1)
         A = [true false; false true]
-        (F, D) = bwdist(A)
-        @test F == [1 1; 1 4]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1; 1 4])
+        D = distance_transform(F)
         @test D == [0 1; 1 0]
 
         # (2)
         A = [true true; false true]
-        (F, D) = bwdist(A)
-        @test F == [1 3; 1 4]
+        F = feature_transform(A)
+        @test F == ind2cart([1 3; 1 4])
+        D = distance_transform(F)
         @test D == [0 0; 1 0]
 
         # (3)
         A = [false false; false true]
-        (F, D) = bwdist(A)
-        @test F == [4 4; 4 4]
-        @test isapprox(D, [1.41421 1.0; 1.0 0.0], rtol=0.01)
+        F = feature_transform(A)
+        @test F == ind2cart([4 4; 4 4])
+        D = distance_transform(F)
+        @test D ≈ [sqrt(2) 1.0; 1.0 0.0]
 
         # (4)
         A = [true false true; false true false; true true false]
-        (F, D) = bwdist(A)
-        @test F == [1 1 7; 1 5 5; 3 6 6]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1 7; 1 5 5; 3 6 6])
+        D = distance_transform(F)
         @test D == [0 1 0; 1 0 1; 0 0 1]
 
         # (5)
         A = [false false true; true true false; true true true]
-        (F, D) = bwdist(A)
-        @test F == [2 5 7; 2 5 5; 3 6 9]
+        F = feature_transform(A)
+        @test F == ind2cart([2 5 7; 2 5 5; 3 6 9])
+        D = distance_transform(F)
         @test D == [1 1 0; 0 0 1; 0 0 0]
 
         # (6)
         A = [true false true true; false true false false; false true true false; true false false false]
-        (F, D) = bwdist(A)
-        @test F == [1 1 9 13; 1 6 6 13; 4 7 11 11; 4 4 11 11]
-        @test isapprox(D, [0.0 1.0 0.0 0.0; 1.0 0.0 1.0 1.0; 1.0 0.0 0.0 1.0; 0.0 1.0 1.0 1.41421], rtol=0.01)
+        F = feature_transform(A)
+        @test F == ind2cart([1 1 9 13; 1 6 6 13; 4 7 11 11; 4 4 11 11])
+        D = distance_transform(F)
+        @test D ≈ [0.0 1.0 0.0 0.0; 1.0 0.0 1.0 1.0; 1.0 0.0 0.0 1.0; 0.0 1.0 1.0 sqrt(2)]
     end
 
     @testset "Rectangular Images" begin
         # (1)
         A = [true false true; false true false]
-        (F, D) = bwdist(A)
-        @test F == [1 1 5; 1 4 4]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1 5; 1 4 4])
+        D = distance_transform(F)
         @test D == [0 1 0; 1 0 1]
 
         # (2)
         A = [true false; false false; false true]
-        (F, D) = bwdist(A)
-        @test F == [1 1; 1 6; 6 6]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1; 1 6; 6 6])
+        D = distance_transform(F)
         @test D == [0 1; 1 1; 1 0]
 
         # (3)
         A = [true false false; true false false; false true true; true true true; false true false]
-        (F, D) = bwdist(A)
-        @test F == [1 1 1; 2 2 13; 2 8 13; 4 9 14; 4 10 10]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1 1; 2 2 13; 2 8 13; 4 9 14; 4 10 10])
+        D = distance_transform(F)
         @test D == [0.0 1.0 2.0; 0.0 1.0 1.0; 1.0 0.0 0.0; 0.0 0.0 0.0; 1.0 0.0 1.0]
     end
 
     @testset "Corner Case Images" begin
+        null1 = CartesianIndex((typemin(Int),))
+        null2 = CartesianIndex((typemin(Int),typemin(Int)))
         # (1)
         A = [false]
-        (F, D) = bwdist(A)
-        @test F == [0]
-        @test D == [1]
+        F = feature_transform(A)
+        @test F == [null1]
+        D = distance_transform(F)
+        @test D == [Inf]
 
         # (2)
         A = [true]
-        (F, D) = bwdist(A)
-        @test F == [1]
+        F = feature_transform(A)
+        @test F == ind2cart([1])
+        D = distance_transform(F)
         @test D == [0]
 
         # (3)
         A = [true false]
-        (F, D) = bwdist(A)
-        @test F == [1 1]
+        F = feature_transform(A)
+        @test F == ind2cart([1 1])
+        D = distance_transform(F)
         @test D == [0 1]
 
         # (4)
         A = [false; false]
-        (F, D) = bwdist(A)
-        @test F == [0; 0]
-        @test D == [1.0; 2.0]
+        F = feature_transform(A)
+        @test F == [null1; null1]
+        D = distance_transform(F)
+        @test D == [Inf; Inf]
 
         # (5)
         A = [true; true]
-        (F, D) = bwdist(A)
-        @test F == [1; 2]
+        F = feature_transform(A)
+        @test F == ind2cart([1; 2])
+        D = distance_transform(F)
         @test D == [0; 0]
 
         # (6)
         A = [true; true; false]
-        (F, D) = bwdist(A)
-        @test F == [1; 2; 2]
+        F = feature_transform(A)
+        @test F == ind2cart([1; 2; 2])
+        D = distance_transform(F)
         @test D == [0; 0; 1]
+
+        # (7)
+        A = falses(3,3)
+        F = feature_transform(A)
+        @test all(x->x==null2, F)
+        D = distance_transform(F)
+        @test all(x->x==Inf, D)
+
+        # (8)
+        A = trues(4,2,3)
+        F = feature_transform(A)
+        @test F == ind2cart(reshape(1:length(A), size(A)))
+        D = distance_transform(F)
+        @test all(x->x==0, D)
+    end
+
+    @testset "Anisotropic images" begin
+        A, w = [false false; false true], (3,1)
+        F = feature_transform(A, w)
+        @test F == ind2cart([4 4; 4 4])
+        D = distance_transform(F, w)
+        @test D ≈ [sqrt(10) 3.0; 1.0 0.0]
+
+        A, w = [false false; false true], (1,3)
+        F = feature_transform(A, w)
+        @test F == ind2cart([4 4; 4 4])
+        D = distance_transform(F, w)
+        @test D ≈ [sqrt(10) 1.0; 3.0 0.0]
+
+        A, w = [true false; false true], (3,1)
+        F = feature_transform(A, w)
+        @test F == ind2cart([1 1; 4 4])
+        D = distance_transform(F, w)
+        @test D == [0 1; 1 0]
+
+        A, w = [true false; false true], (1,3)
+        F = feature_transform(A, w)
+        @test F == ind2cart([1 4; 1 4])
+        D = distance_transform(F, w)
+        @test D == [0 1; 1 0]
     end
 end
+
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ include("algorithms.jl")
 include("exposure.jl")
 include("edge.jl")
 include("corner.jl")
+include("bwdist.jl")
 include("distances.jl")
 include("writemime.jl")
 


### PR DESCRIPTION
This revamps #576, which revamps #99. While I was reluctant to wade into this, given that two people (@wkearn and @muhlba91) have both put significant effort into this, I decided I could no longer avoid respecting their heroism. To make sure everyone got due credit, I first rebased #99 on master (assigning credit to @wkearn), then "replayed" #576 on top of that (assigning credit to @muhlba91), and then added my own tweaks.

I almost merged #576 directly (after resolving the merge conflicts), but after profiling it and discovering that indeed `ind2sub` accounted for most of the runtime, I couldn't resist investigating. More importantly, I decided that a return type of `Array{CartesianIndex}` might be more useful to users than `Array{Int}` (where users would have to call `ind2sub` on the output). Since it's difficult to deprecate output-types, I felt it would be better to rework the API before merging.

This splits the former `bwdist` into two functions, `feature_transform` and `distance_transform`. If all you want are the positions, just call `feature_transform`; if you need the distances you call `distance_transform` on the output of `feature_transform`. It also implements support for anisotropic voxels, which might be important for 3d imaging where often the spacing among slices is different than the pixel-spacing within a slice.

The performance is now quite good:
```julia
julia> A = rand(Bool, 500, 500);

julia> using BenchmarkTools

julia> @benchmark feature_transform($A) seconds=1
BenchmarkTools.Trial: 
  samples:          70
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  3.85 mb
  allocs estimate:  11
  minimum time:     13.01 ms (0.00% GC)
  median time:      13.73 ms (0.00% GC)
  mean time:        14.39 ms (0.47% GC)
  maximum time:     21.29 ms (2.09% GC)
```
which is an improvement by a factor of 5 over #576, and a factor of ~40 over #99.
