### PR TITLE
WIP: Move restrict and imresize to ImageTransformations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,7 @@ Colors 0.7.0
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3.0
 ImageCore
+ImageTransformations
 ImageFiltering
 AxisArrays
 ImageAxes

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -47,10 +47,12 @@ using IndirectArrays, MappedArrays
 const is_little_endian = ENDIAN_BOM == 0x04030201
 
 @reexport using ImageCore
+@reexport using ImageTransformations
 @reexport using ImageAxes
 @reexport using ImageMetadata
 @reexport using ImageFiltering
 
+import ImageTransformations: restrict
 using ImageMetadata: ImageMetaAxis
 
 using Base.Cartesian  # TODO: delete this

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -488,22 +488,7 @@ Like `findlocalmaxima`, but returns the coordinates of the smallest elements.
 findlocalminima(img::AbstractArray, region=coords_spatial(img), edges=true) =
         findlocalextrema(img, region, edges, Base.Order.Reverse)
 
-### restrict, for reducing the image size by 2-fold
-# This properly anti-aliases. The only "oddity" is that edges tend towards zero under
-# repeated iteration.
-# This implementation is considerably faster than the one in Grid,
-# because it traverses the array in storage order.
-if isdefined(:restrict)
-    import Grid.restrict
-end
-
-"""
-`imgr = restrict(img[, region])` performs two-fold reduction in size
-along the dimensions listed in `region`, or all spatial coordinates if
-`region` is not specified.  It anti-aliases the image as it goes, so
-is better than a naive summation over 2x2 blocks.
-"""
-restrict(img::AbstractArray, ::Tuple{}) = img
+# restrict for AxisArray and ImageMeta
 restrict(img::AxisArray, ::Tuple{}) = img
 restrict(img::ImageMeta, ::Tuple{}) = img
 
@@ -521,7 +506,7 @@ function restrict{T,N}(img::AxisArray{T,N}, region::RegionType=coords_spatial(im
 end
 
 function restrict{Ax}(img::Union{AxisArray,ImageMetaAxis}, ::Type{Ax})
-    A = _restrict(img.data, axisdim(img, Ax))
+    A = ImageTransformations._restrict(img.data, axisdim(img, Ax))
     AxisArray(A, replace_axis(modax(img[Ax]), axes(img)))
 end
 
@@ -539,154 +524,6 @@ function modax(ax)
 end
 
 modax(ax, inregion::Bool) = inregion ? modax(ax) : ax
-
-function restrict(A::AbstractArray, region::RegionType=coords_spatial(A))
-    for dim in region
-        A = _restrict(A, dim)
-    end
-    A
-end
-
-function _restrict{T,N}(A::AbstractArray{T,N}, dim::Integer)
-    if size(A, dim) <= 2
-        return A
-    end
-    newsz = ntuple(i->i==dim?restrict_size(size(A,dim)):size(A,i), Val{N})
-    out = Array{typeof(A[1]/4+A[2]/2),N}(newsz)
-    restrict!(out, A, dim)
-    out
-end
-
-# out should have efficient linear indexing
-for N = 1:5
-    @eval begin
-        function restrict!{T}(out::AbstractArray{T,$N}, A::AbstractArray, dim)
-            if isodd(size(A, dim))
-                half = convert(eltype(T), 0.5)
-                quarter = convert(eltype(T), 0.25)
-                indx = 0
-                if dim == 1
-                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = d==1 ? i_d+1 : i_d) begin
-                        nxt = convert(T, @nref $N A j)
-                        out[indx+=1] = half*(@nref $N A i) + quarter*nxt
-                        for k = 3:2:size(A,1)-2
-                            prv = nxt
-                            i_1 = k
-                            j_1 = k+1
-                            nxt = convert(T, @nref $N A j)
-                            out[indx+=1] = quarter*(prv+nxt) + half*(@nref $N A i)
-                        end
-                        i_1 = size(A,1)
-                        out[indx+=1] = quarter*nxt + half*(@nref $N A i)
-                    end
-                else
-                    strd = stride(out, dim)
-                    # Must initialize the i_dim==1 entries with zero
-                    @nexprs $N d->sz_d=d==dim?1:size(out,d)
-                    @nloops $N i d->(1:sz_d) begin
-                        (@nref $N out i) = zero(T)
-                    end
-                    stride_1 = 1
-                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
-                    @nexprs $N d->offset_d = 0
-                    ispeak = true
-                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; ispeak=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
-                        indx = offset_0
-                        if ispeak
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                out[indx+=1] += half*(@nref $N A i)
-                            end
-                        else
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = quarter*(@nref $N A i)
-                                out[indx+=1] += tmp
-                                out[indx+strd] = tmp
-                            end
-                        end
-                    end
-                end
-            else
-                threeeighths = convert(eltype(T), 0.375)
-                oneeighth = convert(eltype(T), 0.125)
-                indx = 0
-                if dim == 1
-                    z = convert(T, zero(A[1]))
-                    @inbounds @nloops $N i d->(d==1 ? (1:1) : (1:size(A,d))) d->(j_d = i_d) begin
-                        c = d = z
-                        for k = 1:size(out,1)-1
-                            a = c
-                            b = d
-                            j_1 = 2*k
-                            i_1 = j_1-1
-                            c = convert(T, @nref $N A i)
-                            d = convert(T, @nref $N A j)
-                            out[indx+=1] = oneeighth*(a+d) + threeeighths*(b+c)
-                        end
-                        out[indx+=1] = oneeighth*c+threeeighths*d
-                    end
-                else
-                    fill!(out, zero(T))
-                    strd = stride(out, dim)
-                    stride_1 = 1
-                    @nexprs $N d->(stride_{d+1} = stride_d*size(out,d))
-                    @nexprs $N d->offset_d = 0
-                    peakfirst = true
-                    @inbounds @nloops $N i d->(d==1?(1:1):(1:size(A,d))) d->(if d==dim; peakfirst=isodd(i_d); offset_{d-1} = offset_d+(div(i_d+1,2)-1)*stride_d; else; offset_{d-1} = offset_d+(i_d-1)*stride_d; end) begin
-                        indx = offset_0
-                        if peakfirst
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = @nref $N A i
-                                out[indx+=1] += threeeighths*tmp
-                                out[indx+strd] += oneeighth*tmp
-                            end
-                        else
-                            for k = 1:size(A,1)
-                                i_1 = k
-                                tmp = @nref $N A i
-                                out[indx+=1] += oneeighth*tmp
-                                out[indx+strd] += threeeighths*tmp
-                            end
-                        end
-                    end
-                end
-            end
-        end
-    end
-end
-
-restrict_size(len::Integer) = isodd(len) ? (len+1)>>1 : (len>>1)+1
-
-## imresize
-function imresize!(resized, original::AbstractMatrix)
-    scale1 = (size(original,1)-1)/(size(resized,1)-0.999f0)
-    scale2 = (size(original,2)-1)/(size(resized,2)-0.999f0)
-    for jr = 0:size(resized,2)-1
-        jo = scale2*jr
-        ijo = trunc(Int, jo)
-        fjo = jo - oftype(jo, ijo)
-        @inbounds for ir = 0:size(resized,1)-1
-            io = scale1*ir
-            iio = trunc(Int, io)
-            fio = io - oftype(io, iio)
-            tmp = (1-fio)*((1-fjo)*original[iio+1,ijo+1] +
-                           fjo*original[iio+1,ijo+2]) +
-                  + fio*((1-fjo)*original[iio+2,ijo+1] +
-                         fjo*original[iio+2,ijo+2])
-            resized[ir+1,jr+1] = convertsafely(eltype(resized), tmp)
-        end
-    end
-    resized
-end
-
-imresize(original, new_size) = size(original) == new_size ? copy!(similar(original), original) : imresize!(similar(original, new_size), original)
-
-convertsafely{T<:AbstractFloat}(::Type{T}, val) = convert(T, val)
-convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)
-convertsafely{T<:Integer}(::Type{T}, val::AbstractFloat) = round(T, val)
-convertsafely{T}(::Type{T}, val) = convert(T, val)
 
 
 function imlineardiffusion{T}(img::Array{T,2}, dt::AbstractFloat, iterations::Integer)

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -506,7 +506,7 @@ function restrict{T,N}(img::AxisArray{T,N}, region::RegionType=coords_spatial(im
 end
 
 function restrict{Ax}(img::Union{AxisArray,ImageMetaAxis}, ::Type{Ax})
-    A = ImageTransformations._restrict(img.data, axisdim(img, Ax))
+    A = restrict(img.data, axisdim(img, Ax))
     AxisArray(A, replace_axis(modax(img[Ax]), axes(img)))
 end
 

--- a/src/map-deprecated.jl
+++ b/src/map-deprecated.jl
@@ -285,6 +285,12 @@ ScaleMinMax{To<:Colorant,CV<:AbstractRGB}(::Type{To}, img::AbstractArray{CV}) = 
 
 similar{T,F,To,From,S}(mapi::ScaleMinMax{To,From,S}, ::Type{T}, ::Type{F}) = ScaleMinMax{T,F,S}(convert(F,mapi.min), convert(F.mapi.max), mapi.s)
 
+# these functions are moved to ImageTransformations
+convertsafely{T<:AbstractFloat}(::Type{T}, val) = convert(T, val)
+convertsafely{T<:Integer}(::Type{T}, val::Integer) = convert(T, val)
+convertsafely{T<:Integer}(::Type{T}, val::AbstractFloat) = round(T, val)
+convertsafely{T}(::Type{T}, val) = convert(T, val)
+
 # Implementation
 function immap{To<:RealLike,From<:RealLike}(mapi::ScaleMinMax{To,From}, val::Union{Real,Colorant})
     t = clamp(gray(val), gray(mapi.min), gray(mapi.max))

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -219,6 +219,9 @@ using Base.Test
         @test img2 ≈ A
     end
 
+    # functionality moved to ImageTransformations
+    # tests are here as well to make sure everything
+    # is exported properly.
     @testset "Restriction" begin
         imgcol = colorview(RGB, rand(3,5,6))
         A = reshape([convert(UInt16, i) for i = 1:60], 4, 5, 3)
@@ -396,6 +399,9 @@ using Base.Test
         @test norm((P-Q)[:]) < 1e-10
     end
 
+    # functionality moved to ImageTransformations
+    # tests are here as well to make sure everything
+    # is exported properly.
     @testset "Image resize" begin
         img = zeros(10,10)
         img2 = Images.imresize(img, (5,5))


### PR DESCRIPTION
**NOT MERGE READY**

The branch corresponding to the move of `restrict` and `imresize` to ImageTransformations.jl.
This depends on ImageTransformations.jl being registered in METADATA.

see: https://github.com/JuliaImages/ImageTransformations.jl/pull/4