### PR TITLE
added convex hull algorithm

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -162,7 +162,7 @@ export # types
     imROF,
     feature_transform,
     distance_transform,
-    convexhull
+    convexhull,
 
     #Exposure
     complement,

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -68,6 +68,7 @@ include("distances.jl")
 include("bwdist.jl")
 using .FeatureTransform
 include("deprecated.jl")
+include("convexhull.jl")
 
 export # types
     BlobLoG,
@@ -161,6 +162,7 @@ export # types
     imROF,
     feature_transform,
     distance_transform,
+    convexhull
 
     #Exposure
     complement,
@@ -235,7 +237,7 @@ Algorithms:
     - Edge detection: `imedge`, `imgradients`, `thin_edges`, `magnitude`, `phase`, `magnitudephase`, `orientation`, `canny`
     - Corner detection: `imcorner`, `harris`, `shi_tomasi`, `kitchen_rosenfeld`, `meancovs`, `gammacovs`, `fastcorners`
     - Blob detection: `blob_LoG`, `findlocalmaxima`, `findlocalminima`
-    - Morphological operations: `dilate`, `erode`, `closing`, `opening`, `tophat`, `bothat`, `morphogradient`, `morpholaplace`, `feature_transform`, `distance_transform`
+    - Morphological operations: `dilate`, `erode`, `closing`, `opening`, `tophat`, `bothat`, `morphogradient`, `morpholaplace`, `feature_transform`, `distance_transform`, `convexhull`
     - Connected components: `label_components`, `component_boxes`, `component_lengths`, `component_indices`, `component_subscripts`, `component_centroids`
     - Interpolation: `bilinear_interpolation`
 

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -46,6 +46,14 @@ function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2}, returntype="points
         error("Invalid argument returntype")
     end
 
+    for i in CartesianRange(size(img))
+        if img[i]!=0 && img[i]!=1
+            warn("Input image isn't binary!")
+            warn("Function considers pixel intensity<255 as black")
+            break
+        end
+    end
+
     function getboundarypoints{T<:Images.Gray}(img::AbstractArray{T, 2})
 
         points = CartesianIndex{2}[]

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -1,14 +1,8 @@
 """
 ```
 chull = convexhull(img)
-chull = convexhull(img, "points/boundary/filled")
 ```
-
-Computes the convex hull of a binary image.
-The function can return either of these-
-- vector of vertices of the convex hull
-- image with boundary pixels marked
-- image with convex hull filled
+Computes the convex hull of a binary image and returns the vertices of convex hull as a CartesianIndex array.
 
 In case the image isn't a binary image, it considers pixel intensity<255 as black.
 """

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -73,7 +73,7 @@ function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2}, returntype="points
 
     dist2(a, b) = sum(abs2, (a-b).I)
 
-    function angularsort!(ref, points, img)
+    function angularsort!(points, ref, img)
         last_point = ref
 
         for i in eachindex(points)
@@ -150,7 +150,7 @@ function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2}, returntype="points
             last_point=point
         end
     end
-    angularsort!(last_point, points, img)
+    angularsort!(points, last_point, img)
 
     n_points=length(points)
 

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -7,21 +7,20 @@ Computes the convex hull of a binary image and returns the vertices of convex hu
 
 function convexhull{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
 
-    function getboundarypoints{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
-
+    function getboundarypoints(img)
         points = CartesianIndex{2}[]
-
-        for i in indices(img, 1)
-            ones = find(img[i,:] .==1)
-
-            if length(ones) == 1
-                push!(points, CartesianIndex{2}(i, minimum(ones)))
-            elseif length(ones)!=0
-                push!(points, CartesianIndex{2}(i, minimum(ones)))
-                push!(points, CartesianIndex{2}(i, maximum(ones)))
+        for j = indices(img, 2)
+            v = Base.view(img, :, j)
+            i1 = findfirst(v)
+            if i1 != 0
+                i2 = findlast(v)
+                push!(points, CartesianIndex(i1, j))
+                if i1 != i2
+                    push!(points, CartesianIndex(i2, j))
+                end
             end
         end
-        return points
+        points
     end
 
     function right_oriented(ref, a, b)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -66,8 +66,8 @@ function convexhull{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
 
     # Used Graham scan algorithm
 
-    points = getboundarypoints(img)
-    last_point = CartesianIndex{2}(1, 1)
+    points=getboundarypoints(img)
+    last_point=CartesianIndex(map(r->first(r)-1, indices(img)))
     for point in points
         if point[2]>last_point[2] || (point[2]==last_point[2] && point[1]>last_point[1])
             last_point=point

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -24,11 +24,11 @@ function convexhull{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
     end
 
     function right_oriented(ref, a, b)
-        ((a[2]-ref[2])*(b[1]-ref[1])-(b[2]-ref[2])*(a[1]-ref[1])<0) ? true : false
+        (a[2]-ref[2])*(b[1]-ref[1])-(b[2]-ref[2])*(a[1]-ref[1])<0
     end
 
     function collinear(a, b, c)
-        ((a[2]-c[2])*(b[1]-c[1])-(b[2]-c[2])*(a[1]-c[1])==0) ? true : false
+        (a[2]-c[2])*(b[1]-c[1])-(b[2]-c[2])*(a[1]-c[1])==0
     end
 
     dist2(a, b) = sum(abs2, (a-b).I)

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -3,21 +3,11 @@
 chull = convexhull(img)
 ```
 Computes the convex hull of a binary image and returns the vertices of convex hull as a CartesianIndex array.
-
-In case the image isn't a binary image, it considers pixel intensity<255 as black.
 """
 
-function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2})
+function convexhull{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
 
-    for i in CartesianRange(size(img))
-        if img[i]!=0 && img[i]!=1
-            warn("Input image isn't binary!")
-            warn("Function considers pixel intensity<255 as black")
-            break
-        end
-    end
-
-    function getboundarypoints{T<:Images.Gray}(img::AbstractArray{T, 2})
+    function getboundarypoints{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
 
         points = CartesianIndex{2}[]
 
@@ -104,5 +94,4 @@ function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2})
     end
 
     return convex_hull
-
 end

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -1,0 +1,182 @@
+"""
+```
+chull = convexhull(img)
+chull = convexhull(img, "hull boundary/filled hull")
+```
+
+Computes the convex hull of a binary image.
+"""
+
+function drawline{T<:ColorTypes.Gray}(img::AbstractArray{T, 2}, y0::Int, x0::Int, y1::Int, x1::Int, color)
+    dx = abs(x1 - x0)
+    dy = abs(y1 - y0)
+ 
+    sx = x0 < x1 ? 1 : -1
+    sy = y0 < y1 ? 1 : -1;
+ 
+    err = (dx > dy ? dx : -dy) / 2
+    
+    while true
+        img[y0, x0] = color
+        (x0 != x1 || y0 != y1) || break
+        e2 = err
+        if e2 > -dx
+            err -= dy
+            x0 += sx
+        end
+        if e2 < dy
+            err += dx
+            y0 += sy
+        end
+    end
+
+    img
+end
+
+
+function convexhull{T<:Images.Gray}(img::AbstractArray{T, 2}, returntype="hull boundary")
+
+    if returntype!="hull boundary" && returntype!="filled hull"
+        error("Invalid argument returntype")
+    end
+
+    points = []
+    h, w = size(img)
+
+    #just store first and last point in each row for computing convex hull
+    for i in 1:h
+        first_point_found=false
+        last_point_found=false
+        first_point=[]
+        last_point=[]
+        for j in 1:w
+            if !first_point_found && img[i, j]==1
+                first_point=[i, j]
+                first_point_found=true
+
+            elseif first_point_found && img[i, j]==1
+                last_point=[i, j]
+                last_point_found=true
+            end
+        end
+        if first_point_found
+            push!(points, first_point)
+        end
+        if last_point_found
+            push!(points, last_point)
+        end
+    end
+
+    # Used Graham scan algorithm
+
+    last_point=[-1, -1]
+    for i in 1:h
+        for j in 1:w
+            if img[i,j]==1 && j>last_point[2]
+                last_point=[i, j]
+            elseif img[i,j]==1 && j==last_point[2] && i>last_point[1]
+                last_point=[i, j]
+            end
+        end
+    end
+
+    function right_oriented(a, b)
+        ref=last_point
+        ((a[2]-ref[2])*(b[1]-ref[1])-(b[2]-ref[2])*(a[1]-ref[1])<0) ? true : false
+    end
+
+    function right_oriented(ref, a, b)
+        ((a[2]-ref[2])*(b[1]-ref[1])-(b[2]-ref[2])*(a[1]-ref[1])<0) ? true : false
+    end
+
+    function collinear(a, b, c)
+        ((a[2]-c[2])*(b[1]-c[1])-(b[2]-c[2])*(a[1]-c[1])==0) ? true : false
+    end
+
+    for i in 1:size(points)[1]
+        if(points[i]==last_point)
+            deleteat!(points, i)
+            break
+        end
+    end
+
+    #angular sort wrt last_point
+    sort!(points, lt=right_oriented)
+
+    #if polar angle of 2 points wrt last_point is same, just keep farther point
+    i=0
+    while i<=size(points)[1]
+        i=i+1
+        if i+1>size(points)[1]
+            break
+        end
+
+        if(collinear(last_point,points[i], points[i+1]))
+            if (points[i][1]-last_point[1])^2 + (points[i][2]-last_point[2])^2< (points[i+1][1]-last_point[1])^2 + (points[i+1][2]-last_point[2])^2
+                deleteat!(points, i)
+            else 
+                deleteat!(points, i+1)
+            end
+            i=i-1
+        end
+    end
+
+    n_points=size(points)[1]
+
+    if n_points<3
+        error("Not enough points to compute convex hull.")
+    end
+
+    convex_hull=[]
+    push!(convex_hull, last_point)
+    push!(convex_hull, points[1])
+    push!(convex_hull, points[2])
+
+    for i in 3:n_points
+        while (right_oriented(convex_hull[end],convex_hull[end-1], points[i]))
+            pop!(convex_hull)
+        end
+        push!(convex_hull, points[i])
+    end
+
+
+    chull = zeros(T, h, w)
+    for i = 1:size(convex_hull)[1]
+        chull[convex_hull[i][1], convex_hull[i][2]]=1
+    end
+
+    for i=1:size(convex_hull)[1]-1
+        chull=drawline(chull, convex_hull[i][1], convex_hull[i][2], convex_hull[i+1][1], convex_hull[i+1][2], 1)
+    end
+    chull=drawline(chull, convex_hull[1][1], convex_hull[1][2], convex_hull[end][1], convex_hull[end][2], 1)
+
+    if returntype=="hull boundary"
+        return chull
+    end
+
+    # fill convex hull
+    for i in 1:h
+        first_point_found=false
+        last_point_found=false
+        first_point=[]
+        last_point=[]
+        for j in 1:w
+            if !first_point_found && chull[i, j]==1
+                first_point=[i, j]
+                first_point_found=true
+
+            elseif first_point_found && chull[i, j]==1
+                last_point=[i, j]
+                last_point_found=true
+            end
+        end
+        if first_point_found && last_point_found
+            chull=drawline(chull, first_point[1], first_point[2], last_point[1], last_point[2], 1)
+        end
+    end
+
+    if returntype=="filled hull"
+        return chull
+    end
+
+end

--- a/src/convexhull.jl
+++ b/src/convexhull.jl
@@ -86,7 +86,7 @@ function convexhull{T<:Union{Bool,Gray{Bool}}}(img::AbstractArray{T, 2})
     push!(convex_hull, points[2])
 
     for i in 3:n_points
-        while (right_oriented(convex_hull[end],convex_hull[end-1], points[i]))
+        while (right_oriented(convex_hull[end],convex_hull[end-1], points[i]) || collinear(convex_hull[end],convex_hull[end-1], points[i]))
             pop!(convex_hull)
         end
         push!(convex_hull, points[i])

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -440,7 +440,7 @@ using Base.Test
 
     @testset "Convex Hull" begin
         A = zeros(50, 30)
-        A= convert(Array{Images.Gray}, A)
+        A= convert(Array{Bool}, A)
         A[25,1]=1
         A[1,10]=1
         A[10,10]=1
@@ -448,7 +448,7 @@ using Base.Test
         A[40,30]=1
         A[40,10]=1
         A[50,10]=1
-        B = convexhull(A)
+        B = @inferred convexhull(A)
         C = CartesianIndex{}[]
         push!(C, CartesianIndex{}(25,1))
         push!(C, CartesianIndex{}(1,10))
@@ -464,8 +464,8 @@ using Base.Test
              0.0, 0.0, 0.0, 0.0, 0.0,
              0.0, 0.0, 1.0, 0.0, 0.0]
         A = reshape(A, 5, 5)
-        A = convert(Array{Images.Gray}, A)
-        B = convexhull(A)
+        A = convert(Array{Bool}, A)
+        B = B = @inferred convexhull(A)
         C = CartesianIndex{}[]
         push!(C, CartesianIndex{}(1,3))
         push!(C, CartesianIndex{}(2,2))

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -468,7 +468,6 @@ using Base.Test
         B = B = @inferred convexhull(A)
         C = CartesianIndex{}[]
         push!(C, CartesianIndex{}(1,3))
-        push!(C, CartesianIndex{}(2,2))
         push!(C, CartesianIndex{}(3,1))
         push!(C, CartesianIndex{}(3,5))
         push!(C, CartesianIndex{}(5,3))

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -449,7 +449,7 @@ using Base.Test
         A[40,30]=1
         A[40,10]=1
         A[50,10]=1
-        B = convexhull(A, "hull boundary")
+        B = convexhull(A, "boundary")
         @test size(B)==size(A)
         @test typeof(B)==typeof(A)
         @test B[25,1]==1
@@ -460,7 +460,7 @@ using Base.Test
         @test B[40,10]==0
         @test B[50,10]==1
 
-        B = convexhull(A, "filled hull")
+        B = convexhull(A, "filled")
         @test size(B)==size(A)
         @test typeof(B)==typeof(A)
         @test B[25,1]==1
@@ -495,8 +495,8 @@ using Base.Test
         C = reshape(C, 5, 5)
         C = convert(Array{Images.Gray}, C)
 
-        @test B==convexhull(A, "hull boundary")
-        @test C==convexhull(A, "filled hull")
+        @test B==convexhull(A, "boundary")
+        @test C==convexhull(A, "filled")
     end
 
 end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -471,6 +471,32 @@ using Base.Test
         @test B[40,10]==1
         @test B[50,10]==1
 
+        A = [0.0, 0.0, 1.0, 0.0, 0.0,
+             0.0, 1.0, 1.0, 0.0, 0.0,
+             1.0, 0.0, 0.0, 1.0, 1.0,
+             0.0, 0.0, 0.0, 0.0, 0.0,
+             0.0, 0.0, 1.0, 0.0, 0.0]
+        A = reshape(A, 5, 5)
+        A = convert(Array{Images.Gray}, A)
+
+        B = [0.0, 0.0, 1.0, 0.0, 0.0,
+             0.0, 1.0, 0.0, 1.0, 0.0,
+             1.0, 0.0, 0.0, 0.0, 1.0,
+             0.0, 1.0, 0.0, 1.0, 0.0,
+             0.0, 0.0, 1.0, 0.0, 0.0]
+        B = reshape(B, 5, 5)
+        B = convert(Array{Images.Gray}, B)
+
+        C = [0.0, 0.0, 1.0, 0.0, 0.0,
+             0.0, 1.0, 1.0, 1.0, 0.0,
+             1.0, 1.0, 1.0, 1.0, 1.0,
+             0.0, 1.0, 1.0, 1.0, 0.0,
+             0.0, 0.0, 1.0, 0.0, 0.0]
+        C = reshape(C, 5, 5)
+        C = convert(Array{Images.Gray}, C)
+
+        @test B==convexhull(A, "hull boundary")
+        @test C==convexhull(A, "filled hull")
     end
 
 end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -439,7 +439,6 @@ using Base.Test
     end
 
     @testset "Convex Hull" begin
-        println("Convex hull tests running")
         A = zeros(50, 30)
         A= convert(Array{Images.Gray}, A)
         A[25,1]=1
@@ -449,27 +448,15 @@ using Base.Test
         A[40,30]=1
         A[40,10]=1
         A[50,10]=1
-        B = convexhull(A, "boundary")
-        @test size(B)==size(A)
-        @test typeof(B)==typeof(A)
-        @test B[25,1]==1
-        @test B[1,10]==1
-        @test B[10,10]==0
-        @test B[10,30]==1
-        @test B[40,30]==1
-        @test B[40,10]==0
-        @test B[50,10]==1
-
-        B = convexhull(A, "filled")
-        @test size(B)==size(A)
-        @test typeof(B)==typeof(A)
-        @test B[25,1]==1
-        @test B[1,10]==1
-        @test B[10,10]==1
-        @test B[10,30]==1
-        @test B[40,30]==1
-        @test B[40,10]==1
-        @test B[50,10]==1
+        B = convexhull(A)
+        C = CartesianIndex{}[]
+        push!(C, CartesianIndex{}(25,1))
+        push!(C, CartesianIndex{}(1,10))
+        push!(C, CartesianIndex{}(10,30))
+        push!(C, CartesianIndex{}(40,30))
+        push!(C, CartesianIndex{}(50,10))
+        @test typeof(B)==Array{CartesianIndex{2},1}
+        @test sort(B)==sort(C)
 
         A = [0.0, 0.0, 1.0, 0.0, 0.0,
              0.0, 1.0, 1.0, 0.0, 0.0,
@@ -478,25 +465,15 @@ using Base.Test
              0.0, 0.0, 1.0, 0.0, 0.0]
         A = reshape(A, 5, 5)
         A = convert(Array{Images.Gray}, A)
-
-        B = [0.0, 0.0, 1.0, 0.0, 0.0,
-             0.0, 1.0, 0.0, 1.0, 0.0,
-             1.0, 0.0, 0.0, 0.0, 1.0,
-             0.0, 1.0, 0.0, 1.0, 0.0,
-             0.0, 0.0, 1.0, 0.0, 0.0]
-        B = reshape(B, 5, 5)
-        B = convert(Array{Images.Gray}, B)
-
-        C = [0.0, 0.0, 1.0, 0.0, 0.0,
-             0.0, 1.0, 1.0, 1.0, 0.0,
-             1.0, 1.0, 1.0, 1.0, 1.0,
-             0.0, 1.0, 1.0, 1.0, 0.0,
-             0.0, 0.0, 1.0, 0.0, 0.0]
-        C = reshape(C, 5, 5)
-        C = convert(Array{Images.Gray}, C)
-
-        @test B==convexhull(A, "boundary")
-        @test C==convexhull(A, "filled")
+        B = convexhull(A)
+        C = CartesianIndex{}[]
+        push!(C, CartesianIndex{}(1,3))
+        push!(C, CartesianIndex{}(2,2))
+        push!(C, CartesianIndex{}(3,1))
+        push!(C, CartesianIndex{}(3,5))
+        push!(C, CartesianIndex{}(5,3))
+        @test typeof(B)==Array{CartesianIndex{2},1}
+        @test sort(B)==sort(C)
     end
 
 end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -438,6 +438,41 @@ using Base.Test
 
     end
 
+    @testset "Convex Hull" begin
+        println("Convex hull tests running")
+        A = zeros(50, 30)
+        A= convert(Array{Images.Gray}, A)
+        A[25,1]=1
+        A[1,10]=1
+        A[10,10]=1
+        A[10,30]=1
+        A[40,30]=1
+        A[40,10]=1
+        A[50,10]=1
+        B = convexhull(A, "hull boundary")
+        @test size(B)==size(A)
+        @test typeof(B)==typeof(A)
+        @test B[25,1]==1
+        @test B[1,10]==1
+        @test B[10,10]==0
+        @test B[10,30]==1
+        @test B[40,30]==1
+        @test B[40,10]==0
+        @test B[50,10]==1
+
+        B = convexhull(A, "filled hull")
+        @test size(B)==size(A)
+        @test typeof(B)==typeof(A)
+        @test B[25,1]==1
+        @test B[1,10]==1
+        @test B[10,10]==1
+        @test B[10,30]==1
+        @test B[40,30]==1
+        @test B[40,10]==1
+        @test B[50,10]==1
+
+    end
+
 end
 
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,5 @@ include("corner.jl")
 include("bwdist.jl")
 include("distances.jl")
 include("writemime.jl")
-
 info("\n\nBeginning of tests with deprecation warnings\n\n")
 include("old/runtests.jl")


### PR DESCRIPTION
The method convexhull computes the convex hull of a binary image using Graham scan algorithm. The method can return either the boundary of the convex hull or the filled out convex hull. I have also added some tests for convexhull.