### PR TITLE
Changed return type of canny

### DIFF
--- a/src/edge.jl
+++ b/src/edge.jl
@@ -402,7 +402,7 @@ function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, 
         lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], lowerThreshold * 100)
     end
     img_thresholded = hysteresis_thresholding(img_nonMaxSup, upperThreshold, lowerThreshold)
-    edges = map(i -> i < 0.9 ? zero(Bool) : one(Bool), img_thresholded)
+    edges = map(i -> i >= 0.9, img_thresholded)
     edges
 end
 

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -402,8 +402,7 @@ function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, 
         lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], lowerThreshold * 100)
     end
     img_thresholded = hysteresis_thresholding(img_nonMaxSup, upperThreshold, lowerThreshold)
-    S = eltype(img_thresholded)
-    edges = map(i -> i < 0.9 ? zero(S) : one(S), img_thresholded)
+    edges = map(i -> i < 0.9 ? zero(Bool) : one(Bool), img_thresholded)
     edges
 end
 

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -33,37 +33,39 @@ global checkboard
         #General Checks
         img = zeros(10, 10)
         edges = canny(img)
-        @test all(edges .== 0.0)
+        @test eltype(edges) == Bool
+        @test all(! edges)
 
         #Box Edges
 
         img[2:end-1, 2:end-1] = 1
         edges = canny(img)
-        @test all(edges[2:end-1, 2] .== 1.0)
-        @test all(edges[2:end-1, end-1] .== 1.0)
-        @test all(edges[2, 2:end-1] .== 1.0)
-        @test all(edges[end-1, 2:end-1] .== 1.0)
-        @test all(edges[3:end-2, 3:end-2] .== 0.0)
+        @test all(edges[2:end-1, 2])
+        @test all(edges[2:end-1, end-1])
+        @test all(edges[2, 2:end-1])
+        @test all(edges[end-1, 2:end-1])
+        @test all(! edges[3:end-2, 3:end-2])
 
         edges = canny(img, 1.4, 0.9/8, 0.2/8, percentile = false)
-        @test all(edges[2:end-1, 2] .== 1.0)
-        @test all(edges[2:end-1, end-1] .== 1.0)
-        @test all(edges[2, 2:end-1] .== 1.0)
-        @test all(edges[end-1, 2:end-1] .== 1.0)
-        @test all(edges[3:end-2, 3:end-2] .== 0.0)
+        @test all(edges[2:end-1, 2])
+        @test all(edges[2:end-1, end-1])
+        @test all(edges[2, 2:end-1])
+        @test all(edges[end-1, 2:end-1])
+        @test all(! edges[3:end-2, 3:end-2])
 
         #Checkerboard - Corners are not detected as Edges!
         img = checkerboard(Gray, 5, 3)
         edges = canny(img, 1.4, 0.8, 0.2)
+        @test eltype(edges) == Bool
         id = [1,2,3,4,6,7,8,9,10,12,13,14,15]
-        @test all(edges[id, id] .== zero(Gray))
+        @test all(! edges[id, id])
         id = [5, 11]
         id2 = [1,2,3,4,7,8,9,12,13,14,15]
         id3 = [5,6,10,11]
-        @test all(edges[id, id2] .== one(Gray))
-        @test all(edges[id2, id] .== one(Gray))
-        @test all(edges[id, id3] .== zero(Gray))
-        @test all(edges[id3, id] .== zero(Gray))
+        @test all(edges[id, id2])
+        @test all(edges[id2, id])
+        @test all(! edges[id, id3])
+        @test all(! edges[id3, id])
 
         #Diagonal Edge
         img = zeros(10,10)
@@ -71,10 +73,11 @@ global checkboard
         img[diagind(img, 1)] = 1
         img[diagind(img, -1)] = 1
         edges = canny(img)
-        @test all(edges[diagind(edges, 2)] .== 1.0)
-        @test all(edges[diagind(edges, -2)] .== 1.0)
+        @test eltype(edges) == Bool
+        @test all(edges[diagind(edges, 2)])
+        @test all(edges[diagind(edges, -2)])
         nondiags = setdiff(1:1:100, union(diagind(edges, 2), diagind(edges, -2)))
-        @test all(edges[nondiags] .== 0.0)
+        @test all(! edges[nondiags])
 
         #Checks Hysteresis Thresholding
         img = ones(Gray{N0f8}, (10, 10))


### PR DESCRIPTION
As canny will return a binary image, an `Array{Bool}` would be more memory efficient than `Array{Float64}`.