### PR TITLE
changed default percentile option for canny

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -60,8 +60,8 @@ using Base.Cartesian  # TODO: delete this
 """
 Percentile - Used to pass arguments to functions as a percentile rather than an absolute value
 
-e.g.,   canny(img, 1.4, (0.8,0.2)) uses absolute threshold
-        canny(img, 1.4, (Percentile(0.8), Percentile(0.2))) uses quantiles of the edge magnitude image as threshold
+e.g.,   canny(img, 1.4, (80, 20)) uses absolute threshold
+        canny(img, 1.4, (Percentile(80), Percentile(20))) uses percentiles of the edge magnitude image as threshold
 
 """
 immutable Percentile{T} <: Real p::T end

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -75,6 +75,7 @@ include("convexhull.jl")
 export # types
     BlobLoG,
     ColorizedArray,
+    Percentile,
 
     # macros
     @test_approx_eq_sigma_eps,

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -57,6 +57,15 @@ using ImageMetadata: ImageMetaAxis
 
 using Base.Cartesian  # TODO: delete this
 
+"""
+Percentile - Used to pass arguments to functions as a percentile rather than an absolute value
+
+e.g.,   canny(img, 1.4, (0.8,0.2)) uses absolute threshold
+        canny(img, 1.4, (Percentile(0.8), Percentile(0.2))) uses quantiles of the edge magnitude image as threshold
+
+"""
+immutable Percentile{T} <: Real p::T end
+
 include("map-deprecated.jl")
 include("overlays-deprecated.jl")
 include("labeledarrays.jl")

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -76,3 +76,12 @@ Base.@deprecate_binding LabeledArray ColorizedArray
 @deprecate ColorizedArray{T,N}(intensity::AbstractArray{T,N}, label::AbstractArray, colors::Vector{RGB}) ColorizedArray(intensity, IndirectArray(label, colors))
 
 @deprecate imcomplement(img::AbstractArray) complement.(img)
+
+function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = true)
+    depwarn("canny(img, sigma, upperThreshold, lowerThreshold; percentile=true) is deprecated.\n Please use canny(img, (upperThreshold, lowerThreshold), sigma) or canny(img, (Percentile(upperThreshold), Percentile(lowerThreshold)), sigma)",:canny)
+    if percentile==true
+        canny(img_gray, (Percentile(upperThreshold), Percentile(lowerThreshold)), sigma)
+    else
+        canny(img_gray, (upperThreshold, lowerThreshold), sigma)
+    end
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -80,7 +80,7 @@ Base.@deprecate_binding LabeledArray ColorizedArray
 function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = true)
     depwarn("canny(img, sigma, upperThreshold, lowerThreshold; percentile=true) is deprecated.\n Please use canny(img, (upperThreshold, lowerThreshold), sigma) or canny(img, (Percentile(upperThreshold), Percentile(lowerThreshold)), sigma)",:canny)
     if percentile==true
-        canny(img_gray, (Percentile(upperThreshold), Percentile(lowerThreshold)), sigma)
+        canny(img_gray, (Percentile(100*upperThreshold), Percentile(100*lowerThreshold)), sigma)
     else
         canny(img_gray, (upperThreshold, lowerThreshold), sigma)
     end

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -376,6 +376,16 @@ function thin_edges_nonmaxsup_subpix(img, gradientangles,
 end
 
 """
+Percentile - Used to pass arguments to functions as a percentile rather than an absolute value
+
+e.g.,   canny(img, 1.4, (0.8,0.2)) uses absolute threshold
+        canny(img, 1.4, (Percentile(0.8), Percentile(0.2))) uses quantiles of the edge magnitude image as threshold
+
+"""
+immutable Percentile{T} <: Real p::T end
+
+
+"""
 ```
 canny_edges = canny(img, sigma = 1.4, upperThreshold = 0.80, lowerThreshold = 0.20)
 ```
@@ -385,21 +395,23 @@ Performs Canny Edge Detection on the input image.
 Parameters :
 
   sigma :           Specifies the standard deviation of the gaussian filter
-  upperThreshold :  Upper bound for hysteresis thresholding
-  lowerThreshold :  Lower bound for hysteresis thresholding
+  threshold:        Tuple of upper bound and lower bound for hysteresis thresholding
   astype :          Specifies return type of result
   percentile :      Specifies if upperThreshold and lowerThreshold should be used
                     as quantiles or absolute values
 
 """
-function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = false)
+function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, threshold::Tuple{N,N}=(0.8,0.2))
     img_grayf = imfilter(img_gray, KernelFactors.IIRGaussian((sigma,sigma)), NA())
     img_grad_y, img_grad_x = imgradients(img_grayf, KernelFactors.sobel)
     img_mag, img_phase = magnitude_phase(img_grad_x, img_grad_y)
     img_nonMaxSup = thin_edges_nonmaxsup(img_mag, img_phase)
-    if percentile
-        upperThreshold = StatsBase.percentile(img_nonMaxSup[:], upperThreshold * 100)
-        lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], lowerThreshold * 100)
+    if N<:Percentile{}
+        upperThreshold = StatsBase.percentile(img_nonMaxSup[:], threshold[1].p)
+        lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], threshold[2].p)
+    else
+        upperThreshold = threshold[1]
+        lowerThreshold = threshold[2]
     end
     img_thresholded = hysteresis_thresholding(img_nonMaxSup, upperThreshold, lowerThreshold)
     edges = map(i -> i >= 0.9, img_thresholded)

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -418,6 +418,7 @@ function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_g
     edges
 end
 
+canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, threshold::Tuple{N,N})=canny(img_gray, 1.4, threshold)
 canny(img::AbstractMatrix, args...) = canny(convert(Array{Gray}, img), args...)
 
 function hysteresis_thresholding{T}(img_nonMaxSup::AbstractArray{T, 2}, upperThreshold::Number, lowerThreshold::Number)

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -376,16 +376,6 @@ function thin_edges_nonmaxsup_subpix(img, gradientangles,
 end
 
 """
-Percentile - Used to pass arguments to functions as a percentile rather than an absolute value
-
-e.g.,   canny(img, 1.4, (0.8,0.2)) uses absolute threshold
-        canny(img, 1.4, (Percentile(0.8), Percentile(0.2))) uses quantiles of the edge magnitude image as threshold
-
-"""
-immutable Percentile{T} <: Real p::T end
-
-
-"""
 ```
 canny_edges = canny(img, sigma = 1.4, upperThreshold = 0.80, lowerThreshold = 0.20)
 ```
@@ -401,7 +391,7 @@ Parameters :
                     as quantiles or absolute values
 
 """
-function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, threshold::Tuple{N,N}=(0.8,0.2))
+function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, threshold::Tuple{N,N}, sigma::Number = 1.4)
     img_grayf = imfilter(img_gray, KernelFactors.IIRGaussian((sigma,sigma)), NA())
     img_grad_y, img_grad_x = imgradients(img_grayf, KernelFactors.sobel)
     img_mag, img_phase = magnitude_phase(img_grad_x, img_grad_y)
@@ -418,7 +408,6 @@ function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_g
     edges
 end
 
-canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, threshold::Tuple{N,N})=canny(img_gray, 1.4, threshold)
 canny(img::AbstractMatrix, args...) = canny(convert(Array{Gray}, img), args...)
 
 function hysteresis_thresholding{T}(img_nonMaxSup::AbstractArray{T, 2}, upperThreshold::Number, lowerThreshold::Number)

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -392,7 +392,7 @@ Parameters :
                     as quantiles or absolute values
 
 """
-function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = true)
+function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = false)
     img_grayf = imfilter(img_gray, KernelFactors.IIRGaussian((sigma,sigma)), NA())
     img_grad_y, img_grad_x = imgradients(img_grayf, KernelFactors.sobel)
     img_mag, img_phase = magnitude_phase(img_grad_x, img_grad_y)

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -385,7 +385,7 @@ Performs Canny Edge Detection on the input image.
 Parameters :
 
   sigma :           Specifies the standard deviation of the gaussian filter
-  threshold:        Tuple of upper bound and lower bound for hysteresis thresholding
+  (upper, lower) :  Bounds for hysteresis thresholding
   astype :          Specifies return type of result
   percentile :      Specifies if upperThreshold and lowerThreshold should be used
                     as quantiles or absolute values

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -384,12 +384,9 @@ Performs Canny Edge Detection on the input image.
 
 Parameters :
 
-  sigma :           Specifies the standard deviation of the gaussian filter
   (upper, lower) :  Bounds for hysteresis thresholding
-  astype :          Specifies return type of result
-  percentile :      Specifies if upperThreshold and lowerThreshold should be used
-                    as quantiles or absolute values
-
+  sigma :           Specifies the standard deviation of the gaussian filter
+  
 """
 function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, threshold::Tuple{N,N}, sigma::Number = 1.4)
     img_grayf = imfilter(img_gray, KernelFactors.IIRGaussian((sigma,sigma)), NA())

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -394,11 +394,9 @@ function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_g
     img_mag, img_phase = magnitude_phase(img_grad_x, img_grad_y)
     img_nonMaxSup = thin_edges_nonmaxsup(img_mag, img_phase)
     if N<:Percentile{}
-        upperThreshold = StatsBase.percentile(img_nonMaxSup[:], threshold[1].p)
-        lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], threshold[2].p)
+        upperThreshold ,lowerThreshold = StatsBase.percentile(img_nonMaxSup[:], [threshold[i].p for i=1:2])
     else
-        upperThreshold = threshold[1]
-        lowerThreshold = threshold[2]
+        upperThreshold, lowerThreshold = threshold
     end
     img_thresholded = hysteresis_thresholding(img_nonMaxSup, upperThreshold, lowerThreshold)
     edges = map(i -> i >= 0.9, img_thresholded)

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -32,14 +32,14 @@ global checkboard
     @testset "Canny Edge Detection" begin
         #General Checks
         img = zeros(10, 10)
-        edges = canny(img)
+        edges = canny(img, percentile=true)
         @test eltype(edges) == Bool
         @test all(! edges)
 
         #Box Edges
 
         img[2:end-1, 2:end-1] = 1
-        edges = canny(img)
+        edges = canny(img, percentile=true)
         @test all(edges[2:end-1, 2])
         @test all(edges[2:end-1, end-1])
         @test all(edges[2, 2:end-1])
@@ -55,7 +55,7 @@ global checkboard
 
         #Checkerboard - Corners are not detected as Edges!
         img = checkerboard(Gray, 5, 3)
-        edges = canny(img, 1.4, 0.8, 0.2)
+        edges = canny(img, 1.4, 0.8, 0.2, percentile=true)
         @test eltype(edges) == Bool
         id = [1,2,3,4,6,7,8,9,10,12,13,14,15]
         @test all(! edges[id, id])
@@ -72,7 +72,7 @@ global checkboard
         img[diagind(img)] = 1
         img[diagind(img, 1)] = 1
         img[diagind(img, -1)] = 1
-        edges = canny(img)
+        edges = canny(img, percentile=true)
         @test eltype(edges) == Bool
         @test all(edges[diagind(edges, 2)])
         @test all(edges[diagind(edges, -2)])

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -39,7 +39,7 @@ global checkboard
         #Box Edges
 
         img[2:end-1, 2:end-1] = 1
-        edges = canny(img, (Percentile(0.8), Percentile(0.2)))
+        edges = canny(img, (Percentile(80), Percentile(20)))
         @test all(edges[2:end-1, 2])
         @test all(edges[2:end-1, end-1])
         @test all(edges[2, 2:end-1])
@@ -55,7 +55,7 @@ global checkboard
 
         #Checkerboard - Corners are not detected as Edges!
         img = checkerboard(Gray, 5, 3)
-        edges = canny(img, (Percentile(0.8), Percentile(0.2)), 1.4)
+        edges = canny(img, (Percentile(80), Percentile(20)), 1.4)
         @test eltype(edges) == Bool
         id = [1,2,3,4,6,7,8,9,10,12,13,14,15]
         @test all(! edges[id, id])
@@ -72,7 +72,7 @@ global checkboard
         img[diagind(img)] = 1
         img[diagind(img, 1)] = 1
         img[diagind(img, -1)] = 1
-        edges = canny(img, (Percentile(0.8),Percentile(0.2)))
+        edges = canny(img, (Percentile(80),Percentile(20)))
         @test eltype(edges) == Bool
         @test all(edges[diagind(edges, 2)])
         @test all(edges[diagind(edges, -2)])

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -32,21 +32,21 @@ global checkboard
     @testset "Canny Edge Detection" begin
         #General Checks
         img = zeros(10, 10)
-        edges = canny(img, percentile=true)
+        edges = canny(img)
         @test eltype(edges) == Bool
         @test all(! edges)
 
         #Box Edges
 
         img[2:end-1, 2:end-1] = 1
-        edges = canny(img, percentile=true)
+        edges = canny(img, (Percentile(0.8), Percentile(0.2)))
         @test all(edges[2:end-1, 2])
         @test all(edges[2:end-1, end-1])
         @test all(edges[2, 2:end-1])
         @test all(edges[end-1, 2:end-1])
         @test all(! edges[3:end-2, 3:end-2])
 
-        edges = canny(img, 1.4, 0.9/8, 0.2/8, percentile = false)
+        edges = canny(img, 1.4, (0.9/8, 0.2/8))
         @test all(edges[2:end-1, 2])
         @test all(edges[2:end-1, end-1])
         @test all(edges[2, 2:end-1])
@@ -55,7 +55,7 @@ global checkboard
 
         #Checkerboard - Corners are not detected as Edges!
         img = checkerboard(Gray, 5, 3)
-        edges = canny(img, 1.4, 0.8, 0.2, percentile=true)
+        edges = canny(img, 1.4, (Percentile(0.8), Percentile(0.2)))
         @test eltype(edges) == Bool
         id = [1,2,3,4,6,7,8,9,10,12,13,14,15]
         @test all(! edges[id, id])
@@ -72,7 +72,7 @@ global checkboard
         img[diagind(img)] = 1
         img[diagind(img, 1)] = 1
         img[diagind(img, -1)] = 1
-        edges = canny(img, percentile=true)
+        edges = canny(img)
         @test eltype(edges) == Bool
         @test all(edges[diagind(edges, 2)])
         @test all(edges[diagind(edges, -2)])

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -32,7 +32,7 @@ global checkboard
     @testset "Canny Edge Detection" begin
         #General Checks
         img = zeros(10, 10)
-        edges = canny(img)
+        edges = canny(img, (0.8, 0.2))
         @test eltype(edges) == Bool
         @test all(! edges)
 
@@ -46,7 +46,7 @@ global checkboard
         @test all(edges[end-1, 2:end-1])
         @test all(! edges[3:end-2, 3:end-2])
 
-        edges = canny(img, 1.4, (0.9/8, 0.2/8))
+        edges = canny(img, (0.9/8, 0.2/8), 1.4)
         @test all(edges[2:end-1, 2])
         @test all(edges[2:end-1, end-1])
         @test all(edges[2, 2:end-1])
@@ -55,7 +55,7 @@ global checkboard
 
         #Checkerboard - Corners are not detected as Edges!
         img = checkerboard(Gray, 5, 3)
-        edges = canny(img, 1.4, (Percentile(0.8), Percentile(0.2)))
+        edges = canny(img, (Percentile(0.8), Percentile(0.2)), 1.4)
         @test eltype(edges) == Bool
         id = [1,2,3,4,6,7,8,9,10,12,13,14,15]
         @test all(! edges[id, id])
@@ -72,7 +72,7 @@ global checkboard
         img[diagind(img)] = 1
         img[diagind(img, 1)] = 1
         img[diagind(img, -1)] = 1
-        edges = canny(img)
+        edges = canny(img, (Percentile(0.8),Percentile(0.2)))
         @test eltype(edges) == Bool
         @test all(edges[diagind(edges, 2)])
         @test all(edges[diagind(edges, -2)])


### PR DESCRIPTION
I have changed the default value of percentile parameter to false. The algorithm is usually used with absolute thresholds and other popular libraries also don't use percentile as default option.