### PR TITLE
Fix `n_scales` condition in `gaussian_pyramid`

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -889,7 +889,7 @@ function gaussian_pyramid{T,N}(img::AbstractArray{T,N}, n_scales::Int, downsampl
     img_scaled = pyramid_scale(img_smoothed_main, downsample)
     prev = convert(typeof(img_scaled), img)
     pyramid = typeof(img_scaled)[prev]
-    if n_scales > 1
+    if n_scales ≥ 1
         # Take advantage of the work we've already done
         push!(pyramid, img_scaled)
         prev = img_scaled

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -208,6 +208,11 @@ using Base.Test
             @test all(Bool[isapprox(v, 0, atol = 0.01) for v in p[h, :]])
             @test all(Bool[isapprox(v, 0, atol = 0.01) for v in p[:, w]])
         end
+
+        #608
+        pyramidlevel1 = gaussian_pyramid(rand(32,32), 1, 2, 1.0)
+        @test length(pyramidlevel1) == 2
+        @test size.(pyramidlevel1) == [(32,32), (16,16)]
     end
 
     @testset "fft and ifft" begin


### PR DESCRIPTION
According to wikipedia:
* `n_scales = 0`: level-0(original image)
* `n_scales = 1` : level-1(1/2 resolution)
* …