### PR TITLE
Expunge `percentile` and `method` as (keyword) arguments from Images API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,21 @@
+# v0.10
+
+New features:
+
+- added `Percentile` to disambiguate the interpretation of
+  thresholds. A raw number `x` will now be interpreted as an absolute
+  threshold, whereas `Percentile(x)` (with `0 <= x <= 100`) will
+  choose an absolute threshold based on the distribution of values in
+  the input array.
+
+API changes:
+
+- `canny` passes the threshold as a 2-tuple and uses `Percentile`
+  rather than a `percentile` keyword. It now issues a deprecation
+  warning when used with default arguments.
+
+- `imcorner` now uses `Percentile`. The old syntax issues a deprecation warning.
+
 # v0.9
 
 Breaking changes:

--- a/src/corner.jl
+++ b/src/corner.jl
@@ -17,21 +17,22 @@ The threshold is assumed to be a percentile value unless `percentile` is set to 
 """
 function imcorner(img::AbstractArray; method::Function = harris, args...)
     responses = method(img; args...)
-    corners = falses(size(img))
-    maxima = map(CartesianIndex{2}, findlocalmaxima(responses))
+    corners = similar(img, Bool)
+    fill!(corners, false)
+    maxima = map(CartesianIndex, findlocalmaxima(responses))
     for m in maxima corners[m] = true end
     corners
 end
 
-function imcorner(img::AbstractArray, threshold, percentile; method::Function = harris, args...)
+function imcorner(img::AbstractArray, threshold; method::Function = harris, args...)
     responses = method(img; args...)
+    map(i -> i > threshold, responses)
+end
 
-    if percentile == true
-        threshold = StatsBase.percentile(vec(responses), threshold * 100)
-    end
-
-    corners = map(i -> i > threshold, responses)
-    corners
+function imcorner(img::AbstractArray, thresholdp::Percentile; method::Function = harris, args...)
+    responses = method(img; args...)
+    threshold = StatsBase.percentile(vec(responses), thresholdp.p)
+    map(i -> i > threshold, responses)
 end
 
 """

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -96,3 +96,9 @@ function imcorner(img::AbstractArray, threshold, percentile;
         imcorner(img, threshold; method=method, args...)
     end
 end
+
+function imedge(img::AbstractArray, method::AbstractString, border::AbstractString="replicate")
+    f = ImageFiltering.kernelfunc_lookup(method)
+    depwarn("`imedge(img, \"$method\", args...)` is deprecated, please use `imedge(img, $f, args...)` instead.", :imedge)
+    imedge(img, f, border)
+end

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -79,9 +79,20 @@ Base.@deprecate_binding LabeledArray ColorizedArray
 
 function canny{T<:NumberLike}(img_gray::AbstractMatrix{T}, sigma::Number = 1.4, upperThreshold::Number = 0.90, lowerThreshold::Number = 0.10; percentile::Bool = true)
     depwarn("canny(img, sigma, $upperThreshold, $lowerThreshold; percentile=$percentile) is deprecated.\n Please use canny(img, ($upperThreshold, $lowerThreshold), sigma) or canny(img, (Percentile($(100*upperThreshold)), Percentile($(100*lowerThreshold))), sigma)",:canny)
-    if percentile==true
+    if percentile
         canny(img_gray, (Percentile(100*upperThreshold), Percentile(100*lowerThreshold)), sigma)
     else
         canny(img_gray, (upperThreshold, lowerThreshold), sigma)
+    end
+end
+
+function imcorner(img::AbstractArray, threshold, percentile;
+                  method::Function = harris, args...)
+    if percentile == true # NB old function didn't require Bool, this ensures conversion
+        depwarn("imcorner(img, $threshold, true; ...) is deprecated. Please use imcorner(img, Percentile($(100*threshold)); ...) instead.", :imcorner)
+        imcorner(img, Percentile(100*threshold); method=method, args...)
+    else
+        depwarn("imcorner(img, $threshold, false; ...) is deprecated. Please use imcorner(img, $threshold; ...) instead.", :imcorner)
+        imcorner(img, threshold; method=method, args...)
     end
 end

--- a/src/edge.jl
+++ b/src/edge.jl
@@ -93,20 +93,19 @@ end
 # Return the x-y gradients and magnitude and phase of gradients in an image
 """
 ```
-grad_x, grad_y, mag, orient = imedge(img, [method], [border])
+grad_y, grad_x, mag, orient = imedge(img, kernelfun=KernelFactors.ando3, border="replicate")
 ```
 
-Edge-detection filtering. `method` is one of `"sobel"`, `"prewitt"`, `"ando3"`,
-`"ando4"`, `"ando4_sep"`, `"ando5"`, or `"ando5_sep"`, defaulting to `"ando3"`
-(see the functions of the same name for more information).  `border` is any of
-the boundary conditions specified in `padarray`.
+Edge-detection filtering. `kernelfun` is a valid kernel function for
+[`imgradients`](@ref), defaulting to [`KernelFactors.ando3`](@ref).
+`border` is any of the boundary conditions specified in `padarray`.
 
 Returns a tuple `(grad_x, grad_y, mag, orient)`, which are the horizontal
 gradient, vertical gradient, and the magnitude and orientation of the strongest
 edge, respectively.
 """
-function imedge(img::AbstractArray, method::AbstractString="ando3", border::AbstractString="replicate")
-    grad_x, grad_y = imgradients(img, method, border)
+function imedge(img::AbstractArray, kernelfun=KernelFactors.ando3, border::AbstractString="replicate")
+    grad_x, grad_y = imgradients(img, kernelfun, border)
     mag = magnitude(grad_x, grad_y)
     orient = orientation(grad_x, grad_y)
     return (grad_x, grad_y, mag, orient)
@@ -386,7 +385,7 @@ Parameters :
 
   (upper, lower) :  Bounds for hysteresis thresholding
   sigma :           Specifies the standard deviation of the gaussian filter
-  
+
 """
 function canny{T<:NumberLike, N<:Union{NumberLike,Percentile{NumberLike}}}(img_gray::AbstractMatrix{T}, threshold::Tuple{N,N}, sigma::Number = 1.4)
     img_grayf = imfilter(img_gray, KernelFactors.IIRGaussian((sigma,sigma)), NA())

--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -22,6 +22,12 @@ This assumes the input `img` has intensities between 0 and 1.
 imstretch(img::AbstractArray, m::Number, slope::Number) = _imstretch(float(img), m, slope)
 imstretch(img::ImageMeta, m::Number, slope::Number) = shareproperties(img, imstretch(data(img), m, slope))
 
+"""
+    y = complement(x)
+
+Take the complement `1-x` of `x`.  If `x` is a color with an alpha channel,
+the alpha channel is left untouched.
+"""
 complement(x) = one(x)-x
 complement(x::TransparentColor) = typeof(x)(complement(color(x)), alpha(x))
 

--- a/test/corner.jl
+++ b/test/corner.jl
@@ -9,10 +9,13 @@ using Base.Test, Images, Colors, FixedPointNumbers
     	img[4:17, 4:17] = 1
     	img[8:13, 8:13] = 0
 
-    	expected_corners = zeros(20, 20)
-    	ids = map(CartesianIndex{2}, [(4, 4), (4, 17), (17, 4), (17, 17), (8, 8), (8, 13), (13, 8), (13, 13)])
-    	for id in ids expected_corners[id] = 1 end
     	corners = imcorner(img, method = harris)
+        expected_corners = falses(20, 20)
+        ids = map(CartesianIndex{2}, [(4, 4), (4, 17), (17, 4), (17, 17), (8, 8), (8, 13),
+                                      (13, 8), (13, 13)])
+        for id in ids expected_corners[id] = true end
+        expected_harris = copy(expected_corners)
+
     	for id in ids @test corners[id]  end
     	@test sum(corners .!= expected_corners) < 3
     	corners = imcorner(img, method = shi_tomasi)
@@ -28,7 +31,7 @@ using Base.Test, Images, Colors, FixedPointNumbers
     end
 
     @testset "Harris" begin
-	Ac = imcorner(A, 0.99, true, method = harris)
+	Ac = imcorner(A, Percentile(99), method = harris)
 	# check corners
 	@test Ac[16,16]
 	@test Ac[16,26]
@@ -63,7 +66,7 @@ using Base.Test, Images, Colors, FixedPointNumbers
     end
 
     @testset "Shi-Tomasi" begin
-	Ac = imcorner(A, 0.99, true, method = shi_tomasi)
+	Ac = imcorner(A, Percentile(99), method = shi_tomasi)
 	# check corners
 	@test Ac[16,16]
 	@test Ac[16,26]
@@ -100,7 +103,7 @@ using Base.Test, Images, Colors, FixedPointNumbers
     @testset "Kitchen-Rosenfeld" begin
 	A[10:30, 10:30] = 1
 	A[15:25, 15:25] = 0
-	Ac = imcorner(A, 0.99, true, method = kitchen_rosenfeld)
+	Ac = imcorner(A, Percentile(99), method = kitchen_rosenfeld)
 	@test Ac[10, 10]
 	@test Ac[10, 30]
 	@test Ac[30, 10]

--- a/test/edge.jl
+++ b/test/edge.jl
@@ -4,6 +4,18 @@ global checkboard
 
 @testset "Edge" begin
 
+    @testset "imedge" begin
+        img = zeros(8, 10)
+        img[:, 5] = 1
+        grad_y, grad_x, mag, orient = imedge(img)
+        @test all(x->x==0, grad_y)
+        target_x = zeros(8, 10); target_x[:, 4] = 0.5; target_x[:, 6] = -0.5
+        @test grad_x == target_x
+        @test mag == abs.(grad_x)
+        target_orient = zeros(8, 10); target_orient[:, 6] = pi
+        @test orient ≈ target_orient
+    end
+
     EPS = 1e-14
 
     kernelmethods = (KernelFactors.sobel, KernelFactors.prewitt, KernelFactors.ando3,


### PR DESCRIPTION
After #607 (merged as #616), `canny` disambiguated its threshold using the new `Percentile` type. Before making a new release, for consistency we should get rid of all functions that use an argument corresponding to a `percentile::Bool`. The only other one I'm aware of is `imcorner`.

As a matter of principle, when adding deprecation warnings it's probably a good idea to deprecate anything else related that seems to need changing; this is a kindness to users, to prevent too much API churn. Therefore, I decided to make the `method` keyword argument a positional one. Julia can't dispatch on keyword arguments, so the result wouldn't be type-stable. That's not always important, but it also no longer seems very Julian to me to do this by a keyword argument. The new API supports the following syntaxes:
```julia
imcorner(img)
imcorner(harris, img)
imcorner(img) do A
    harris(A, k=0.1)
end
```
and quite a few others. In particular the `do`-block syntax is a nice way to modify the keywords of the detector-method without having to pass them as arguments to `imcorner` itself (which makes it clearer "who" those keywords are intended for).

My main concern is that other functions in Images (e.g. `imfilter`) take a function as a later argument. I'd be interested in seeing whether people think this is a problem.

@tejus-gupta and @annimesh2809, as our GSoC candidates you might want to look over the first commit as a model of how to handle "difficult" deprecations. I admit this is quite a pain in the neck, but given that we don't really know how many people are using this package and these features (it could be no one, or it could be thousands of people), we have to be pretty careful. As you look that commit over, features worth taking note of:
- I added descriptions of the changes to `NEWS.md`
- The functions added to `src/deprecations.jl` are quite long, but the purpose was to suggest the syntax closest to the one that user is actually calling the function with. So `imcorner(img; method=shi_tomasi)` will suggest `imcorner(shi_tomasi, img)` and `imcorner(img; method=shi_tomasi, border="reflect")` will suggest the `do`-block syntax. I also took care to make sure that the keyword arguments would print as a user might type them (they don't by default).
- I added tests of all the new syntaxes. Because we weren't testing all the old syntaxes, I also added tests for those to our "deprecated" tests.

Naturally, while you (or anyone else) look these commits over you notice problems, by all means suggest improvements! It can go both ways :smile:.
