### PR TITLE
iterate over last dimension when grouping N-D tables of images

### DIFF
--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -39,7 +39,7 @@ map8(x::Number) = N0f8(x)
 
 function _show_odd{T<:ColorantMatrix}(io::IO, m::MIME"text/html", imgs::AbstractArray{T, 1})
     # display a vector of images in a row
-    for j = 1:length(imgs)
+    for j in eachindex(imgs)
         write(io, "<td style='text-align:center;vertical-align:middle; margin: 0.5em;border:1px #90999f solid;border-collapse:collapse'>")
         show_element(IOContext(io, thumbnail=true), imgs[j])
         write(io, "</td>")
@@ -48,7 +48,7 @@ end
 
 function _show_odd{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::AbstractArray{T, N})
     colons = ([Colon() for i=1:(N-1)]...)
-    for i = 1:size(imgs, N)
+    for i in indices(imgs, N)
         write(io, "<td style='text-align:center;vertical-align:middle; margin: 0.5em;border:1px #90999f solid;border-collapse:collapse'>")
         _show_even(io, m, view(imgs, colons..., i)) # show even
         write(io, "</td>")
@@ -60,7 +60,7 @@ function _show_even{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::Abst
     centering = center ? " style='margin: auto'" : ""
     write(io, "<table$centering>")
     write(io, "<tbody>")
-    for i = 1:size(imgs, N)
+    for i in indices(imgs, N)
         write(io, "<tr>")
         _show_odd(io, m, view(imgs, colons..., i)) # show odd
         write(io, "</tr>")

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -50,7 +50,7 @@ function _show_odd{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::Abstr
     colons = ([Colon() for i=1:(N-1)]...)
     for i = 1:size(imgs, 1)
         write(io, "<td style='text-align:center;vertical-align:middle; margin: 0.5em;border:1px #90999f solid;border-collapse:collapse'>")
-        _show_even(io, m, view(imgs, i, colons...)) # show even
+        _show_even(io, m, view(imgs, colons..., i)) # show even
         write(io, "</td>")
     end
 end
@@ -62,7 +62,7 @@ function _show_even{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::Abst
     write(io, "<tbody>")
     for i = 1:size(imgs, 1)
         write(io, "<tr>")
-        _show_odd(io, m, view(imgs, i, colons...)) # show odd
+        _show_odd(io, m, view(imgs, colons..., i)) # show odd
         write(io, "</tr>")
     end
     write(io, "</tbody>")

--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -48,7 +48,7 @@ end
 
 function _show_odd{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::AbstractArray{T, N})
     colons = ([Colon() for i=1:(N-1)]...)
-    for i = 1:size(imgs, 1)
+    for i = 1:size(imgs, N)
         write(io, "<td style='text-align:center;vertical-align:middle; margin: 0.5em;border:1px #90999f solid;border-collapse:collapse'>")
         _show_even(io, m, view(imgs, colons..., i)) # show even
         write(io, "</td>")
@@ -60,7 +60,7 @@ function _show_even{T<:ColorantMatrix, N}(io::IO, m::MIME"text/html", imgs::Abst
     centering = center ? " style='margin: auto'" : ""
     write(io, "<table$centering>")
     write(io, "<tbody>")
-    for i = 1:size(imgs, 1)
+    for i = 1:size(imgs, N)
         write(io, "<tr>")
         _show_odd(io, m, view(imgs, colons..., i)) # show odd
         write(io, "</tr>")


### PR DESCRIPTION
Fixes #625 (assuming that that is, in fact, an error). 

Before:

![screenshot from 2017-04-13 16 58 35](https://cloud.githubusercontent.com/assets/591886/25024170/d9af5422-206a-11e7-8716-d31004510ea4.png)

After:

![screenshot from 2017-04-13 16 57 38](https://cloud.githubusercontent.com/assets/591886/25024134/b7bafd30-206a-11e7-9db6-b15a60463486.png)

My reasoning is that this is more consistent with the way arrays are printed as text in Julia:

```julia
[fill(z * z2) for x in 1:2, y in 1:2, z in [0.5, 1], z2 in [0.5, 1]]
```

gives:

```
2×2×2×2 Array{Array{Float64,0},4}:
[:, :, 1, 1] =
 0.25  0.25
 0.25  0.25

[:, :, 2, 1] =
 0.5  0.5
 0.5  0.5

[:, :, 1, 2] =
 0.5  0.5
 0.5  0.5

[:, :, 2, 2] =
 1.0  1.0
 1.0  1.0
```
