### PR TITLE
fix ambiguity with restrict() from ImageTransformations

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -494,9 +494,9 @@ findlocalminima(img::AbstractArray, region=coords_spatial(img), edges=true) =
 restrict(img::AxisArray, ::Tuple{}) = img
 restrict(img::ImageMeta, ::Tuple{}) = img
 
-const RegionType = Union{Dims,Vector{Int}}
+restrict(img::ImageMeta, region::Vector{Int}) = restrict(img, (region...))
 
-function restrict(img::ImageMeta, region::RegionType=coords_spatial(img))
+function restrict(img::ImageMeta, region::Dims=coords_spatial(img))
     shareproperties(img, restrict(data(img), region))
 end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -500,7 +500,9 @@ function restrict(img::ImageMeta, region::RegionType=coords_spatial(img))
     shareproperties(img, restrict(data(img), region))
 end
 
-function restrict{T,N}(img::AxisArray{T,N}, region::RegionType=coords_spatial(img))
+restrict(img::AxisArray, region::Vector{Int}) = restrict(img, (region...))
+
+function restrict{T,N}(img::AxisArray{T,N}, region::Dims=coords_spatial(img))
     inregion = falses(ndims(img))
     inregion[[region...]] = true
     inregiont = (inregion...,)::NTuple{N,Bool}

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -266,6 +266,9 @@ using Base.Test
         img1 = colorview(RGB, fill(0.9, 3, 5, 5))
         img2 = colorview(RGB, fill(N0f8(0.9), 3, 5, 5))
         @test isapprox(channelview(restrict(img1)), channelview(restrict(img2)), rtol=0.01)
+
+        imgmeta = ImageMeta(imgcol, Dict(:myprop=>1))
+        @test restrict(imgmeta, [1, 2]) == @inferred(restrict(imgmeta, (1, 2)))
     end
 
     @testset "Erode/ dilate" begin


### PR DESCRIPTION
After this change, the tests are closer to passing, but I'm seeing a strange error: 

```
Restriction: Error During Test
  Got an exception of type ErrorException outside of a @test
  return type AxisArrays.AxisArray{ColorTypes.RGB{Float64},2,Array{ColorTypes.RGB{Float64},2},Tuple{AxisArrays.Axis{:y,FloatRange{Float64}},AxisArrays.Axis{:x,Base.OneTo{Int64}}}} does not match inferred return type Union{AxisArrays.AxisArray{ColorTypes.RGB{Float64},2,Array{ColorTypes.RGB{Float64},2},Tuple{AxisArrays.Axis{:y,FloatRange{Float64}},AxisArrays.Axis{:x,Base.OneTo{Int64}}}},AxisArrays.AxisArray{ColorTypes.RGB{Float64},2,FFTViews.FFTView{ColorTypes.RGB{Float64},2,Array{ColorTypes.RGB{Float64},2}},Tuple{AxisArrays.Axis{:y,FloatRange{Float64}},AxisArrays.Axis{:x,Base.OneTo{Int64}}}},AxisArrays.AxisArray{ColorTypes.RGB{Float64},2,OffsetArrays.OffsetArray{ColorTypes.RGB{Float64},2,Array{ColorTypes.RGB{Float64},2}},Tuple{AxisArrays.Axis{:y,FloatRange{Float64}},AxisArrays.Axis{:x,Base.OneTo{Int64}}}}}
   in macro expansion; at /home/rdeits/.julia/v0.5/Images/test/algorithms.jl:263 [inlined]
```

but I can't reproduce that error at the REPL. I'm curious if it will happen on Travis. 