### PR TITLE
more specific test for #623

### DIFF
--- a/test/writemime.jl
+++ b/test/writemime.jl
@@ -81,13 +81,12 @@ using Base.Test
         show(io, MIME"text/html"(), [img() for i=1:2, j=1:2, k=1:2])
     end
     @testset "display matrix of 1-D images" begin
-        flat_img() = zeros(Gray{Float32}, 1)
+        flat_imgs = [zeros(Gray{Float32}, 1)]
         io = IOBuffer()
         # These methods should not invoke the Images.jl display code, but they
         # used to throw errors: https://github.com/JuliaImages/Images.jl/issues/623
-        # show(io, MIME"text/html"(), [flat_img() for i=1:2])
-        # show(io, MIME"text/html"(), [flat_img() for i=1:2, j=1:2])
-        # show(io, MIME"text/html"(), [flat_img() for i=1:2, j=1:2, k=1:2])
+        @test !applicable(Images._show_odd, io, MIME"text/html"(), flat_imgs)
+        @test !applicable(Images._show_even, io, MIME"text/html"(), flat_imgs)
     end
     rm(workdir, recursive=true)
 end


### PR DESCRIPTION
Testing `show()` is somewhat useless, since the whole point of #623 was to prevent any Images.jl code from being called in the first place. This just provides a direct test against the old behavior sneaking back in. 