### PR TITLE
Extend dilate/erode for ImageMeta

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -51,8 +51,9 @@ const is_little_endian = ENDIAN_BOM == 0x04030201
 @reexport using ImageFiltering
 @reexport using ImageMorphology
 
-import ImageTransformations: restrict
 using ImageMetadata: ImageMetaAxis
+import ImageMorphology: dilate, erode
+import ImageTransformations: restrict
 
 using Base.Cartesian  # TODO: delete this
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -606,6 +606,9 @@ function imROF(img::AbstractArray, lambda::Number, iterations::Integer)
     out
 end
 
+# morphological operations for ImageMeta
+dilate(img::ImageMeta, region=coords_spatial(img)) = shareproperties(img, dilate!(copy(data(img)), region))
+erode(img::ImageMeta, region=coords_spatial(img)) = shareproperties(img, erode!(copy(data(img)), region))
 
 # what are these `extr` functions? TODO: documentation
 


### PR DESCRIPTION
As discussed in https://github.com/JuliaImages/ImageMorphology.jl/issues/1

I will remove the definitions from ImageMorphology.jl after they are merged here.