### PR TITLE
improve component_centroids performance

### DIFF
--- a/src/connected.jl
+++ b/src/connected.jl
@@ -272,17 +272,12 @@ function component_subscripts(img::AbstractArray{Int})
 end
 
 "`component_centroids(labeled_array)` -> an array of centroids for each label, including the background label 0"
-function component_centroids(img::AbstractArray{Int})
-    nd = ndims(img)
-    n = [zeros(nd+1) for i=0:maximum(img)]
-    s = size(img)
-    for i=1:length(img)
-        vcur = ind2sub(s,i)
-        vsum = n[img[i]+1]
-        for d=1:nd
-            vsum[d] += vcur[d]
-        end
-        vsum[end] += 1
+function component_centroids(img::AbstractArray{Int,N}) where N
+    len = length(0:maximum(img))
+    n = fill((zero(CartesianIndex{N}), 0), len)
+    @inbounds for I in CartesianRange(size(img))
+        v = img[I] + 1
+        n[v] = n[v] .+ (I, 1)
     end
-    map(x->tuple((x[1:nd]./x[nd+1])...),n)
+    map(v -> n[v][1].I ./ n[v][2], 1:len)
 end

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -402,7 +402,7 @@ using Base.Test
         @test component_lengths(lbltarget) == [2,3,3]
         @test component_indices(lbltarget) == Array{Int64}[[4,5],[1,2,3],[6,7,8]]
         @test component_subscripts(lbltarget) == Array{Tuple}[[(2,2),(1,3)],[(1,1),(2,1),(1,2)],[(2,3),(1,4),(2,4)]]
-        @test component_centroids(lbltarget) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
+        @test @inferred(component_centroids(lbltarget)) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
     end
 
     @testset "Phantoms" begin


### PR DESCRIPTION
As discussed in https://github.com/JuliaImages/Images.jl/issues/677#issuecomment-344284124 .

- makes the function type stable
- about 4x speed improvement on the example discussed in the link above