### PR TITLE
make complement signature more strict. fix #690

### DIFF
--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -29,8 +29,9 @@ Take the complement `1-x` of `x`.  If `x` is a color with an alpha channel,
 the alpha channel is left untouched. Don't forget to add a dot when `x` is
 an array: `complement.(x)`
 """
-complement(x) = oneunit(x)-x
+complement(x::Union{Number,Colorant}) = oneunit(x)-x
 complement(x::TransparentColor) = typeof(x)(complement(color(x)), alpha(x))
+@deprecate complement(x::AbstractArray) complement.(x)
 
 imhist(img::AbstractArray{T}, nbins::Integer = 400) where {T<:Colorant} = imhist(convert(Array{Gray}, img), nbins)
 

--- a/test/exposure.jl
+++ b/test/exposure.jl
@@ -360,6 +360,8 @@ using Base.Test, Images, Colors, FixedPointNumbers
         @test complement(Gray(0.5)) == Gray(0.5)
         @test complement(Gray(0.2)) == Gray(0.8)
         @test all(complement.(img) .== 1 - img)
+        # deprecated (#690)
+        @test all(complement(img) .== 1 - img)
 
         hist = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 


### PR DESCRIPTION
This is one attempt to improve the situation outlined in #690 

I have to admit I am not super happy about this either. That said, I do think we should not let `complement(::Array)` silently return something strange.