### PR TITLE
fix order of dimensions when showing an array of images

### DIFF
--- a/src/showmime.jl
+++ b/src/showmime.jl
@@ -78,6 +78,7 @@ function _show_even(io::IO, m::MIME"text/html", imgs::AbstractArray{T, N}, cente
 end
 
 function Base.show(io::IO, m::MIME"text/html", imgs::AbstractArray{T, N}) where {T<:ColorantMatrix, N}
+    imgs = permutedims(imgs, N:-1:1)
     if N % 2 == 1
         write(io, "<table>")
         write(io, "<tbody>")
@@ -86,6 +87,9 @@ function Base.show(io::IO, m::MIME"text/html", imgs::AbstractArray{T, N}) where 
         write(io, "</tr>")
         write(io, "</tbody>")
         write(io, "</table>")
+        if N == 1
+            write(io, "<div><small>(a vector displayed as a row to save space)</small></div>")
+        end
     else
         _show_even(io, m, imgs, false) # Stack vertically
     end


### PR DESCRIPTION
Before 
![screenshot from 2018-03-09 20-31-08](https://user-images.githubusercontent.com/25916/37213818-28f9795a-23d9-11e8-9f52-bbdaec912f29.png)

After:

![screenshot from 2018-03-09 20-29-36](https://user-images.githubusercontent.com/25916/37213838-353f77a0-23d9-11e8-84f1-faf1dfb9a7e7.png)

@alanedelman suggested the parenthetic in the vector display:

![screenshot from 2018-03-09 19-58-16](https://user-images.githubusercontent.com/25916/37213883-5b0e1766-23d9-11e8-9144-b4f0b7fa26e8.png)

