### PR TITLE
Fixes adjust_gamma so that it works on offset arrays 

### DIFF
--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -270,7 +270,7 @@ adjust_gamma(img::AbstractArray{T}, gamma::Number) where {T<:Number} = _adjust_g
 adjust_gamma(img::AbstractArray{T}, gamma::Number) where {T<:Colorant} = _adjust_gamma(img, gamma, T)
 
 function _adjust_gamma(img::AbstractArray, gamma::Number, C::Type)
-    gamma_corrected_img = zeros(C, size(img))
+    gamma_corrected_img = _fill(oneunit(C), indices(img))
     for I in eachindex(img)
         gamma_corrected_img[I] = _gamma_pixel_rescale(img[I], gamma)
     end
@@ -278,12 +278,15 @@ function _adjust_gamma(img::AbstractArray, gamma::Number, C::Type)
 end
 
 function adjust_gamma(img::AbstractArray{T}, gamma::Number, minval::Number, maxval::Number) where T<:Number
-    gamma_corrected_img = zeros(Float64, size(img))
+    gamma_corrected_img = _fill(oneunit(T), indices(img))
     for I in eachindex(img)
         gamma_corrected_img[I] = _gamma_pixel_rescale(img[I], gamma, minval, maxval)
     end
     gamma_corrected_img
 end
+
+_fill(val, dim) = fill(val, dim) # fallback
+_fill(val, dim::NTuple{N,Base.OneTo}) where {N} = fill(val, map(length, dim))
 
 """
 ```

--- a/test/exposure.jl
+++ b/test/exposure.jl
@@ -125,38 +125,78 @@ using Base.Test, Images, Colors, FixedPointNumbers
         @test img == ret
         @test eltype(ret) == eltype(img)
 
+        imgp = padarray(img, Fill(0, (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
+
         img = oneunits(Gray{N0f8}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test img == ret
         @test eltype(ret) == eltype(img)
 
+        imgp = padarray(img, Fill(0, (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
+
         img = oneunits(Gray{N0f16}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test eltype(ret) == eltype(img)
+
+        imgp = padarray(img, Fill(0, (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
 
         img = oneunits(AGray{N0f8}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test img == ret
         @test eltype(ret) == eltype(img)
 
+        imgp = padarray(img, Fill(0, (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
+
         img = oneunits(RGB{N0f8}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test img == ret
         @test eltype(ret) == eltype(img)
+
+        imgp = padarray(img, Fill(zero(eltype(img)), (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
 
         img = oneunits(RGB{N0f16}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test img == ret
         @test eltype(ret) == eltype(img)
 
+        imgp = padarray(img, Fill(zero(eltype(img)), (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+        @test eltype(retp) == eltype(imgp)
+
         img = oneunits(RGB{Float64}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test all(map((i, r) -> isapprox(i, r), img, ret))
         @test eltype(ret) == eltype(img)
 
+        imgp = padarray(img, Fill(zero(eltype(img)), (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test all(map((i, r) -> isapprox(i, r), imgp, retp))
+        @test eltype(retp) == eltype(imgp)
+
         img = oneunits(ARGB{N0f8}, 10, 10)
         ret = adjust_gamma(img, 1)
         @test img == ret
+
+        imgp = padarray(img, Fill(zero(eltype(img)), (2,2)))
+        retp = adjust_gamma(imgp, 1)
+        @test imgp == retp
+
 
         #Working
 
@@ -361,7 +401,7 @@ using Base.Test, Images, Colors, FixedPointNumbers
         @test complement(Gray(0.2)) == Gray(0.8)
         @test all(complement.(img) .== 1 - img)
         # deprecated (#690)
-        @test all(complement(img) .== 1 - img)
+        @test all(complement.(img) .== 1 - img)
 
         hist = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 


### PR DESCRIPTION
Fixes #686 
###  Implementation Note
Calling `indices(img)` on a canonical array returns a tuple of type `Base.OneTo`. Unfortunately, there is currently no `fill` method defined in `Base` which can take a tuple of `Base.OneTo` as its dimension argument. Hence, I had to explicitly convert the tuple of `Base.OneTo` to a tuple of integers.