### PR TITLE
Eliminate duplicate types already defined in ColorTypes.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,12 +1,13 @@
 julia 0.7-beta
 Reexport
 Colors 0.7.0
+ColorTypes 0.7.4
 ColorVectorSpace 0.2
 FixedPointNumbers 0.3.0
 ImageCore 0.6.0
 ImageTransformations 0.2.2
 ImageFiltering
-ImageMorphology
+ImageMorphology 0.1.1
 ImageDistances 0.0.2
 AxisArrays
 ImageAxes

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -32,16 +32,14 @@ using Reexport
 using ColorVectorSpace, FileIO
 export load, save
 import Colors: Fractional, red, green, blue
-const AbstractGray{T}                    = Color{T,1}
-const TransparentRGB{C<:AbstractRGB,T}   = TransparentColor{C,T,4}
-const TransparentGray{C<:AbstractGray,T} = TransparentColor{C,T,2}
-const NumberLike = Union{Number,AbstractGray}
-const RealLike = Union{Real,AbstractGray}
 import Graphics
 import Graphics: width, height, Point
 using StatsBase  # TODO: eliminate this dependency
 using IndirectArrays, MappedArrays
-# using Compat.TypeUtils
+
+# TODO: can we get rid of these definitions?
+const NumberLike = Union{Number,AbstractGray}
+const RealLike = Union{Real,AbstractGray}
 
 const is_little_endian = ENDIAN_BOM == 0x04030201
 
@@ -195,14 +193,6 @@ export # types
     # algorithms
     backdiffx,
     backdiffy,
-    dilate,
-    erode,
-    opening,
-    closing,
-    tophat,
-    bothat,
-    morphogradient,
-    morpholaplace,
     forwarddiffx,
     forwarddiffy,
     imcorner,
@@ -240,8 +230,6 @@ export # types
     imstretch,
     cliphist,
 
-
-#     imthresh,
     label_components,
     label_components!,
     component_boxes,


### PR DESCRIPTION
This PR fixes issue #731 

It depends on:

- https://github.com/JuliaGraphics/ColorTypes.jl/pull/111
- https://github.com/JuliaGraphics/Colors.jl/pull/320