### PR TITLE
Remove FactCheck from test/REQUIRE

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,5 +1,4 @@
 @osx TestImages
-FactCheck
 @windows ImageMagick
 @linux ImageMagick
 @osx QuartzImageIO


### PR DESCRIPTION
This was breaking tests on 1.0 and higher.