### PR TITLE
Add Boundary filling algorithm

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -186,6 +186,7 @@ export
     component_indices,
     component_subscripts,
     component_centroids,
+    fill_boundaries,
     magnitude,
     magnitude_phase,
     meanfinite,

--- a/src/connected.jl
+++ b/src/connected.jl
@@ -281,3 +281,37 @@ function component_centroids(img::AbstractArray{Int,N}) where N
     end
     map(v -> n[v][1].I ./ n[v][2], 1:len)
 end
+
+"""
+ ```
+ filled_img = fill_boundaries(img)
+ filled_img = fill_boundaries(img, connectivity)
+ ```
+ Return bool array where boundaries between labeled regions are True.
+ Parameters:
+  -  img            = Input image (Boolean array type)
+  -  connectivity   = connectivity takes the same values as in label_components (Default value is 1:ndims(img))
+ """
+function fill_boundaries(img::AbstractArray{Bool},connectivity::Union{Dims, AbstractVector{Int}, BitArray}=1:ndims(img))
+    
+    labels = label_components(img,connectivity)
+    boundaries = zeros(Bool,(size(img)))
+    
+    if ndims(img) == 2
+        M = size(img)[1]
+        N = size(img)[2]
+        for ind in eachindex(img)
+            if ind%M == 1 || ind%M == 0 || ind <= M || ind+M >= M*N     # mark end boundaries
+                 boundaries[ind] = true
+            
+            elseif labels[ind] == labels[ind+1] == labels[ind-1] == labels[ind+M] == labels[ind-M] 
+                continue                                                # ignoring non Boundary pixels
+            
+            else
+                boundaries[ind] = true                              
+            end
+        end
+    end
+    
+    return boundaries
+end


### PR DESCRIPTION
**Closes:** https://github.com/JuliaImages/Images.jl/issues/775
This is the initial version of the algorithm and I have only added support for 2D type images.
If this seems good, I will add a generalized method including 3D images.

**Input Image:**
![yw7sd](https://user-images.githubusercontent.com/23431811/50769476-0dfdfc00-12aa-11e9-8271-853641ed636a.png)
**Result:** 
![screenshot from 2019-01-07 17-58-31](https://user-images.githubusercontent.com/23431811/50769483-122a1980-12aa-11e9-8ebe-d6a5d98ef86b.png)
