### PR TITLE
RFC: replace gitter with slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An image processing library for [Julia](http://julialang.org/).
 [![Build Status](https://travis-ci.org/JuliaImages/Images.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/Images.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/JuliaImages/Images.jl?svg=true&branch=master)](https://ci.appveyor.com/project/timholy/images-jl/branch/master)
 [![codecov](https://codecov.io/gh/JuliaImages/Images.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaImages/Images.jl)
-[![Join the chat at #image-processing](https://img.shields.io/badge/slack-image--processing-blue.svg)](https://julialang.slack.com)
+[![Join the chat at #image-processing](https://img.shields.io/badge/slack-image--processing-blue.svg)](https://julialang.slack.com/messages/CB1R90P8R)
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An image processing library for [Julia](http://julialang.org/).
 [![Build Status](https://travis-ci.org/JuliaImages/Images.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/Images.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/JuliaImages/Images.jl?svg=true&branch=master)](https://ci.appveyor.com/project/timholy/images-jl/branch/master)
 [![codecov](https://codecov.io/gh/JuliaImages/Images.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaImages/Images.jl)
-[![Join the chat at #image-processing](https://img.shields.io/badge/slack-image--processing-blue.svg)](https://julialang.slack.com/messages/CB1R90P8R)
+[![Join the chat at #image-processing](https://img.shields.io/badge/chat-slack%23image--processing-blue.svg)](https://julialang.slack.com/messages/CB1R90P8R)
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An image processing library for [Julia](http://julialang.org/).
 [![Build Status](https://travis-ci.org/JuliaImages/Images.jl.svg?branch=master)](https://travis-ci.org/JuliaImages/Images.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/github/JuliaImages/Images.jl?svg=true&branch=master)](https://ci.appveyor.com/project/timholy/images-jl/branch/master)
 [![codecov](https://codecov.io/gh/JuliaImages/Images.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaImages/Images.jl)
-[![Join the chat at https://gitter.im/JuliaImages/Images.jl](https://badges.gitter.im/JuliaImages/Images.jl.svg)](https://gitter.im/JuliaImages/Images.jl?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at #image-processing](https://img.shields.io/badge/slack-image--processing-blue.svg)](https://julialang.slack.com)
 
 
 ## Documentation


### PR DESCRIPTION
Nowadays julia developers are more active on slack than gitter, so let's deprecate gitter and use slack

Badge options:

1. ![](https://img.shields.io/badge/chat-slack%23image--processing-yellow.svg)
2. ![](https://img.shields.io/badge/chat-on%20slack-yellow.svg)
3. ![](https://img.shields.io/badge/slack-image--processing-yellow.svg)

url options:

1. invitation link: https://slackinvite.julialang.org
2. slack url:  https://julialang.slack.com  directs you to last opened message
3. channel url: https://julialang.slack.com/messages/CB1R90P8R

Flux.jl takes 2-1
My preference list (from most prefered to least):
* 3-1
* 2-3

Let's vote