### PR TITLE
add missing ImageMorphology import (fixes #796)

### DIFF
--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -3,6 +3,7 @@ using OffsetArrays
 import Statistics
 using Statistics: mean, var
 import AxisArrays
+using ImageMorphology: dilate!, erode!
 
 # Compat.@dep_vectorize_2arg Gray atan2
 # Compat.@dep_vectorize_2arg Gray hypot

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -360,6 +360,11 @@ using Test
         @test Ae == cat(Ar, Ag, zeros(4,4), dims=3)
         # issue #311
         @test dilate(trues(3)) == trues(3)
+        # ImageMeta
+        @test data(dilate(ImageMeta(A))) == dilate(A)
+        @test data(dilate(ImageMeta(A), 1:2)) == dilate(A, 1:2)
+        @test data(erode(ImageMeta(A))) == erode(A)
+        @test data(erode(ImageMeta(A), 1:2)) == erode(A, 1:2)
     end
 
     @testset "Opening / closing" begin


### PR DESCRIPTION
fixes https://github.com/JuliaImages/Images.jl/issues/796

`dilate!` and `erode!` are not exported by `ImageMorphology`, and they're called without `using`
https://github.com/JuliaImages/Images.jl/blob/4cc66f9023973b8b0f2165f9738f02f20c378de0/src/algorithms.jl#L653-L654