### PR TITLE
revert CI version to keep julia 0.7 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ os:
     - linux
     - osx
 julia:
+    - 0.7
     - 1.0
-    - 1.1
     - nightly
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
+  - julia_version: 0.7
   - julia_version: 1.0
-  - julia_version: 1.1
   - julia_version: latest
 
 platform:


### PR DESCRIPTION
According to discussion in https://github.com/JuliaImages/ImageCore.jl/pull/71#discussion_r277172826, when we drop the CI test on 0.7 we should drop the compatibility as well.

Since there's already a register PR: https://github.com/JuliaRegistries/General/pull/162, we can keep this version `0.18.0` still compatible with julia `v0.7`. And drop `v0.7` compatibility in the next minor version.