### PR TITLE
use master branch of deps in nightly test stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,25 @@ julia:
     - 0.7
     - 1.0
     - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
+env:
+  - USE_MASTER=true
+  - USE_MASTER=""
+
 notifications:
-    email: false
+  email: false
+matrix:
+  exclude:
+    - julia: 1.0
+      env: USE_MASTER=true
+    - julia: 1.1
+      env: USE_MASTER=true
+    - julia: nightly
+      env: USE_MASTER=""
+  allow_failures:
+  - julia: nightly
+
+before_script:
+  - if [ ! -z "$USE_MASTER" ]; then curl $SCRIPT_URL -o install_master.jl; julia install_master.jl;  fi
 
 after_success:
     # push coverage results to Codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ notifications:
   email: false
 matrix:
   exclude:
-    - julia: 1.0
+    - julia: 0.7
       env: USE_MASTER=true
-    - julia: 1.1
+    - julia: 1.0
       env: USE_MASTER=true
     - julia: nightly
       env: USE_MASTER=""


### PR DESCRIPTION
CI updating work: https://github.com/JuliaImages/Images.jl/issues/805

To make it work, you need:

* set Travis environment variable in https://travis-ci.org/JuliaImages/Images.jl/settings

`SCRIPT_URL=https://gist.githubusercontent.com/johnnychen94/720900fd9e44395beaa0704770c91a36/raw/74f1a02f420a3ccd64b56cfc14111d170f559330/checkout_master.jl`

* retrigger the ci 

---

Other related question:

can we set a daily/weekly Travis cron work on `Images.jl#master`? Or perhaps more aggressively disable `allow_failures` on `nightly`?

By doing this, whenever we want to tag a new release in submodules, we can check if `Images.jl` passes the nightly test stage, and fixes potential bugs if there are.