### PR TITLE
remove array operation red,greed,blue

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -31,7 +31,7 @@ using Reexport
 @reexport using Colors
 using ColorVectorSpace, FileIO
 export load, save
-import Colors: Fractional, red, green, blue
+import Colors: Fractional
 import Graphics
 import Graphics: width, height, Point
 using StatsBase  # TODO: eliminate this dependency

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -143,31 +143,6 @@ end
 
 entropy(img::AbstractArray{C}; kind=:shannon) where {C<:AbstractGray} = entropy(channelview(img), kind=kind)
 
-# functions red, green, and blue
-for (funcname, fieldname) in ((:red, :r), (:green, :g), (:blue, :b))
-    fieldchar = string(fieldname)[1]
-    @eval begin
-        function $funcname(img::AbstractArray{CV}) where CV<:Color
-            T = eltype(CV)
-            out = Array(T, size(img))
-            for i = 1:length(img)
-                out[i] = convert(RGB{T}, img[i]).$fieldname
-            end
-            out
-        end
-
-        function $funcname(img::AbstractArray)
-            pos = search(lowercase(colorspace(img)), $fieldchar)
-            pos == 0 && error("channel $fieldchar not found in colorspace $(colorspace(img))")
-            sliceim(img, "color", pos)
-        end
-    end
-end
-
-"`r = red(img)` extracts the red channel from an RGB image `img`" red
-"`g = green(img)` extracts the green channel from an RGB image `img`" green
-"`b = blue(img)` extracts the blue channel from an RGB image `img`" blue
-
 """
 `m = minfinite(A)` calculates the minimum value in `A`, ignoring any values that are not finite (Inf or NaN).
 """


### PR DESCRIPTION
These array operations are already deprecated, e.g., using `red.(img)` instead of `red(img)`

Actually, with the usage of `Array(T, size(img))` being invalid, these functions are broken but are not caught by any test cases. So deleting them without depwarn is quite safe.