### PR TITLE
break out tuple wrapper to speed up centroid calc, 100x speedup

### DIFF
--- a/src/connected.jl
+++ b/src/connected.jl
@@ -274,10 +274,12 @@ end
 "`component_centroids(labeled_array)` -> an array of centroids for each label, including the background label 0"
 function component_centroids(img::AbstractArray{Int,N}) where N
     len = length(0:maximum(img))
-    n = fill((zero(CartesianIndex{N}), 0), len)
+    n = fill(zero(CartesianIndex{N}), len)
+    counts = fill(0, len)
     @inbounds for I in CartesianIndices(size(img))
         v = img[I] + 1
-        n[v] = n[v] .+ (I, 1)
+        n[v] += I
+        counts[v] += 1
     end
-    map(v -> n[v][1].I ./ n[v][2], 1:len)
+    map(v -> n[v].I ./ counts[v], 1:len)
 end


### PR DESCRIPTION
Master

```julia
julia> a = rand(0:250, 1024, 1024);

julia> @benchmark component_centroids(a)
BenchmarkTools.Trial: 
  memory estimate:  284.09 MiB
  allocs estimate:  10228991
  --------------
  minimum time:     311.128 ms (7.72% GC)
  median time:      318.457 ms (7.66% GC)
  mean time:        322.547 ms (8.68% GC)
  maximum time:     376.423 ms (21.04% GC)
  --------------
  samples:          16
  evals/sample:     1

```

This PR

```julia
julia> a = rand(0:250, 1024, 1024);

julia> @benchmark component_centroids(a)
BenchmarkTools.Trial: 
  memory estimate:  10.31 KiB
  allocs estimate:  5
  --------------
  minimum time:     2.359 ms (0.00% GC)
  median time:      2.865 ms (0.00% GC)
  mean time:        2.872 ms (0.00% GC)
  maximum time:     3.372 ms (0.00% GC)
  --------------
  samples:          1736
  evals/sample:     1

```