### PR TITLE
Please consider adding the colorfulness measurement

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -146,6 +146,7 @@ export
     imadjustintensity,
     imstretch,
     cliphist,
+    colorfulness,
 
     label_components,
     label_components!,

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -973,17 +973,17 @@ Photonics.
 
 """
 function colorfulness(img::AbstractMatrix{<:Color})
-    
-    rg = red.(img) .- green.(img)
+
+    rg = 255 .* (red.(img) .- green.(img))
     μrg, σrg = mean(rg), std(rg)
 
-    yb = 0.5 * (red.(img) .+ green.(img)) - blue.(img)
+    yb = 255 .* (0.5 .* (red.(img) .+ green.(img)) .- blue.(img))
     μyb,  σyb = mean(yb), std(yb)
-
+  
     σrgyb = sqrt(σrg^2 + σyb^2)
     μrgyb = sqrt(μrg^2 + μyb^2)
 
-    return σrgyb+ 0.3 * μrgyb
+    return σrgyb + 0.3 * μrgyb
 
 end
 

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -1,7 +1,7 @@
 using Base: axes1, tail
 using OffsetArrays
 import Statistics
-using Statistics: mean, var
+using Statistics: mean, var, std
 import AxisArrays
 using ImageMorphology: dilate!, erode!
 
@@ -956,3 +956,35 @@ function clearborder(img::AbstractArray, width::Int=1, background::Int=0)
     return new_img
 
 end
+
+
+"""
+
+```
+M =  colorfulness(img)
+```
+
+Calculates the colorfulness of an image according to [1]
+
+[1] Hasler, D. and Süsstrunk, S.E., 2003, June. Measuring colorfulness
+in natural images. In Human vision and electronic imaging VIII
+(Vol. 5007, pp. 87-96). International Society for Optics and
+Photonics.
+
+"""
+function colorfulness(img::AbstractMatrix{<:Color})
+    
+    rg = red.(img) .- green.(img)
+    μrg, σrg = mean(rg), std(rg)
+
+    yb = 0.5 * (red.(img) .+ green.(img)) - blue.(img)
+    μyb,  σyb = mean(yb), std(yb)
+
+    σrgyb = sqrt(σrg^2 + σyb^2)
+    μrgyb = sqrt(μrg^2 + μyb^2)
+
+    return σrgyb+ 0.3 * μrgyb
+
+end
+
+colorfulness(img::AbstractMatrix{<:Gray}) = 0

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -717,7 +717,7 @@ using Test
         @test colorfulness(img) == 0
         img = [RGB{N0f8}(r/255,g/255,b/255) for r in 0:255 for g in 0:255 for b in 0:255]
         img = reshape(img,4096,4096)
-        @test colorfulness(img) > 0.6
+        @test colorfulness(img) > 109
     end
 end
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -707,6 +707,18 @@ using Test
                      0 0 0 0 0]
         @test cleared_img == check_img
     end
+
+    @testset "colorfulness" begin
+        @test colorfulness(testimage("lena_color_512")) > colorfulness(testimage("lena_color_256"))
+        cameraman = testimage("cameraman")
+        @test colorfulness(cameraman) == 0
+        x = convert(Array{Float64}, cameraman)
+        img = RGB.(x, x, x)
+        @test colorfulness(img) == 0
+        img = [RGB{N0f8}(r/255,g/255,b/255) for r in 0:255 for g in 0:255 for b in 0:255]
+        img = reshape(img,4096,4096)
+        @test colorfulness(img) > 0.6
+    end
 end
 
 nothing


### PR DESCRIPTION
The algorithm from [1] measures the colorfulness of a natural image and is useful for evaluating the perceptual impact of image processing techniques.

[1] Hasler, D. and Süsstrunk, S.E., 2003, June. Measuring colorfulness
in natural images. In Human vision and electronic imaging VIII
(Vol. 5007, pp. 87-96). International Society for Optics and
Photonics.