### PR TITLE
Faster imhist

### DIFF
--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -168,7 +168,7 @@ function imhist(img::AbstractArray, edges::AbstractRange)
     o = Base.Order.Forward
     G = graytype(eltype(img))
     for v in img
-        val = convert(G, v)
+        val = real(convert(G, v))
         if val >= edges[end]
             histogram[end] += 1
             continue


### PR DESCRIPTION
Converting each element to `real` makes the `searchsortedlast` call dispatch on the faster method specialized for ranges.

Benchmarks:
```
using BenchmarkTools
using TestImages
img = testimage("lighthouse")
img_gray = Gray.(img)
img_normed = real.(img)
img_float = float.(img_normed)
```

Before:
```
@btime imhist($img)           # 24.367 ms (5 allocations: 386.06 KiB)
@btime imhist($img_gray)      # 23.378 ms (3 allocations: 1.92 KiB)
@btime imhist($img_normed)    # 12.228 ms (3 allocations: 1.92 KiB)
@btime imhist($img_float)     # 14.518 ms (3 allocations: 1.92 KiB)
```
After:
```
@btime imhist($img)           # 14.108 ms (5 allocations: 386.06 KiB)
@btime imhist($img_gray)      # 12.681 ms (3 allocations: 1.92 KiB)
@btime imhist($img_normed)    # 12.379 ms (3 allocations: 1.92 KiB)
@btime imhist($img_float)     # 13.913 ms (3 allocations: 1.92 KiB)
```

