### PR TITLE
test against Julia 1.3 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1
+  - julia_version: 1.3
   - julia_version: latest
 
 platform:


### PR DESCRIPTION
Looks like `1` is no longer linked to latest stable `1.x` release