### PR TITLE
make docs a submodule and add documentation stage in CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docs"]
+	path = docs
+	url = git@github.com:JuliaImages/juliaimages.github.io.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "docs"]
 	path = docs
-	url = git@github.com:JuliaImages/juliaimages.github.io.git
+	url = https://github.com/JuliaImages/juliaimages.github.io.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,12 @@ after_success:
     - julia -e 'cd(Pkg.dir("Images")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
 
 jobs:
-    include:
-        - stage: "Documentation"
-        julia: 1.0
-        os: linux
-        script:
-            - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
-                                                    Pkg.instantiate()'
-            - julia --project=docs/ docs/docs/make.jl
-        after_success: skip
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+      - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                             Pkg.instantiate()'
+      - julia --project=docs/ docs/docs/make.jl
+      after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
     - stage: "Documentation"
       julia: 1.0
       os: linux
+      env:
+        - TRAVIS_REPO_SLUG=github.com/JuliaImages/juliaimages.github.io.git
       script:
       - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
                                              Pkg.instantiate()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,14 @@ notifications:
 after_success:
     # push coverage results to Codecov
     - julia -e 'cd(Pkg.dir("Images")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+
+jobs:
+    include:
+        - stage: "Documentation"
+        julia: 1.0
+        os: linux
+        script:
+            - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()));
+                                                    Pkg.instantiate()'
+            - julia --project=docs/ docs/docs/make.jl
+        after_success: skip


### PR DESCRIPTION
I'm not very sure whether it works as expected, but here's what I expect:

* enable documentation build on `Images.jl` side,
* and furthermore, versioning documentation

If this strategy works, we might also need to adjust the structure of https://github.com/JuliaImages/juliaimages.github.io so that the general folder structure looks normal, it's `docs/docs/` at present.