### PR TITLE
Performance improvements for `build_histogram` and `adjust_histogram`

### DIFF
--- a/test/exposure.jl
+++ b/test/exposure.jl
@@ -96,7 +96,7 @@ eye(m,n) = Matrix{Float64}(I,m,n)
                 @test axes(counts) == (0:length(edges),)
                 # Due to roundoff errors the bins are not the same as in the
                 # integer case above.
-                if T == Gray{Float32}
+                if T == Gray{Float32} || T == Gray{N0f8}
                     @test collect(counts) == [120, 5, 5, 5, 121]
                 else
                     @test collect(counts) == [120, 6, 5, 4, 121]
@@ -123,7 +123,7 @@ eye(m,n) = Matrix{Float64}(I,m,n)
                 img = 200/255:1/255:240/255
                 edges, counts  = build_histogram(T.(img),4,200/255,240/255)
                 @test length(edges) == length(counts) - 1
-                if T == Gray{Float32}
+                if T == Gray{Float32} || T == Gray{N0f8}
                     @test collect(counts) == [0, 10, 10, 10, 11]
                 else
                     @test collect(counts) == [0, 11, 9, 10, 11]
@@ -133,14 +133,8 @@ eye(m,n) = Matrix{Float64}(I,m,n)
                 edges, counts  = build_histogram(T.(img),4)
                 @test axes(counts) == (0:length(edges),)
                 @test length(edges) == length(counts) - 1
-                if T == Gray{N0f16} || T == Gray{N0f8}
-                    @test collect(counts) == [0, 11, 10, 10, 10]
-                elseif T == Gray{Float32}
-                    @test collect(counts) == [0, 10, 10, 10, 11]
-                else
-                    @test collect(counts) == [0, 11, 9, 10, 11]
-                end
-
+                @test all([0, 9, 9, 9, 9] .<= collect(counts) .<= [0, 11, 11, 11, 11])
+                @test sum(counts) == length(img)
             end
         end
 


### PR DESCRIPTION
I started out optimizing `imhist` (due to some benchmarks posted on the `#image-processing` slack channel) but switched to `build_histogram` as the more "sane" implementation. 

Setup:
```julia
julia> using Images, TestImages, BenchmarkTools

julia> img = testimage("light");

julia> imgg = Gray.(img);
```

Master:
```julia
julia> @btime build_histogram(img);
ERROR: MethodError: no method matching build_histogram(::Array{RGB{Normed{UInt8,8}},2}, ::Int64, ::RGB{Normed{UInt8,8}}, ::RGB{Normed{UInt8,8}})
Closest candidates are:
  build_histogram(::AbstractArray, ::Integer) at /home/tim/.julia/dev/Images/src/exposure.jl:326
  build_histogram(::AbstractArray, ::Integer, ::Union{Real, Color{T,1} where T}, ::Union{Real, Color{T,1} where T}) at /home/tim/.julia/dev/Images/src/exposure.jl:321
  build_histogram(::AbstractArray{T,N} where N, ::AbstractRange) where T<:(Color{T,3} where T) at /home/tim/.julia/dev/Images/src/exposure.jl:330
  ...
Stacktrace:
 [1] build_histogram(::Array{RGB{Normed{UInt8,8}},2}, ::Int64) at /home/tim/.julia/dev/Images/src/exposure.jl:326 (repeats 2 times)
...

julia> @btime build_histogram(img, 256);
ERROR: MethodError: no method matching build_histogram(::Array{RGB{Normed{UInt8,8}},2}, ::Int64, ::RGB{Normed{UInt8,8}}, ::RGB{Normed{UInt8,8}})
Closest candidates are:
  build_histogram(::AbstractArray, ::Integer) at /home/tim/.julia/dev/Images/src/exposure.jl:326
  build_histogram(::AbstractArray, ::Integer, ::Union{Real, Color{T,1} where T}, ::Union{Real, Color{T,1} where T}) at /home/tim/.julia/dev/Images/src/exposure.jl:321
  build_histogram(::AbstractArray{T,N} where N, ::AbstractRange) where T<:(Color{T,3} where T) at /home/tim/.julia/dev/Images/src/exposure.jl:330
  ...
Stacktrace:
 [1] build_histogram(::Array{RGB{Normed{UInt8,8}},2}, ::Int64) at /home/tim/.julia/dev/Images/src/exposure.jl:326
...

julia> @btime build_histogram(img, 256, 0, 1);
  11.475 ms (5 allocations: 386.42 KiB)

julia> @btime adjust_histogram(Equalization(), img, 256);
  49.846 ms (15 allocations: 5.63 MiB)

julia> @btime adjust_histogram(Equalization(), imgg, 256);
  32.206 ms (9 allocations: 393.09 KiB)
```

This PR:
```julia
julia> @btime build_histogram(img);
  902.893 μs (3 allocations: 2.27 KiB)

julia> @btime build_histogram(img, 256);
  2.631 ms (6 allocations: 4.52 KiB)

julia> @btime build_histogram(img, 256, 0, 1);
  922.566 μs (6 allocations: 4.53 KiB)

julia> @btime adjust_histogram(Equalization(), img, 256);
  20.114 ms (15 allocations: 5.63 MiB)

julia> @btime adjust_histogram(Equalization(), imgg, 256);
  3.804 ms (11 allocations: 395.30 KiB)
```

Comparison with `imhist`/`histeq`:

```julia
julia> @btime imhist(img, 256);
  14.448 ms (5 allocations: 386.06 KiB)

julia> @btime histeq(img, 256);
  29.787 ms (6 allocations: 1.13 MiB)
```

Not nearly as much an improvement for `adjust_histogram`. There is more that could be done but it would be more of an architecture change.

These were inspired by comparison to PIL and OpenCV. With OpenCV, the naive approach fails for color images (https://stackoverflow.com/questions/15007304/histogram-equalization-not-working-on-color-image-opencv) and for PIL the quality is much worse than what we achieve:

Original:
![orig](https://user-images.githubusercontent.com/1525481/71604762-c95a1900-2b29-11ea-87ae-8c11366e9c69.png)
 
Julia's `adjust_histogram`:
![eqjl](https://user-images.githubusercontent.com/1525481/71604774-d7a83500-2b29-11ea-95e8-56f3326afcd3.png)

PIL's `ImageOps.equalize`:
![eqpil](https://user-images.githubusercontent.com/1525481/71604781-ec84c880-2b29-11ea-95ed-a922b1538489.png)

You can see much more dramatic changes in hue with PIL.