### PR TITLE
[deprecation] shepp_logan and one(::CartesionIndex)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -50,6 +50,7 @@ OffsetArrays = "0.8, 0.9, 0.10, 0.11, 1.0.1"
 Reexport = "0.2"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12"
 StatsBase = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"
+Suppressor = "0.2"
 TiledIteration = "0.2"
 julia = "1"
 
@@ -57,10 +58,10 @@ julia = "1"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["FFTW", "ImageMagick", "LinearAlgebra", "QuartzImageIO", "Random", "Test", "TestImages"]
+test = ["FFTW", "ImageMagick", "LinearAlgebra", "Random", "Suppressor", "Test", "TestImages"]

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -86,6 +86,7 @@ import ImageMorphology: dilate, erode
 import ImageTransformations: restrict
 using TiledIteration: EdgeIterator
 
+include("compat.jl")
 include("misc.jl")
 include("labeledarrays.jl")
 include("algorithms.jl")

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -381,7 +381,7 @@ function findlocalextrema(img::AbstractArray{T,N}, region::Union{Tuple{Int,Varar
     edgeoffset = CartesianIndex(map(!, edges))
     R0 = CartesianIndices(axes(img))
     R = _clippedinds(R0,edgeoffset)
-    rstp = one(first(R0))
+    rstp = oneunit(first(R0))
     Rinterior = _clippedinds(R0,rstp)
     iregion = CartesianIndex(ntuple(d->d∈region, Val(N)))
     Rregion = CartesianIndices(map((f,l)->f:l,(-iregion).I, iregion.I))
@@ -505,7 +505,7 @@ function div(p::AbstractArray{T,3}) where T
     inds = axes(p)[1:2]
     out = similar(p, inds)
     Router = CartesianIndices(inds)
-    rstp = one(first(Router))
+    rstp = oneunit(first(Router))
     Rinner = _clippedinds(Router,rstp)
     # Since most of the points are in the interior, compute them more quickly by avoiding branches
     for I in Rinner
@@ -580,56 +580,6 @@ end
 # morphological operations for ImageMeta
 dilate(img::ImageMeta, region=coords_spatial(img)) = shareproperties(img, dilate!(copy(arraydata(img)), region))
 erode(img::ImageMeta, region=coords_spatial(img)) = shareproperties(img, erode!(copy(arraydata(img)), region))
-
-# phantom images
-
-"""
-```
-phantom = shepp_logan(N,[M]; highContrast=true)
-```
-
-output the NxM Shepp-Logan phantom, which is a standard test image usually used
-for comparing image reconstruction algorithms in the field of computed
-tomography (CT) and magnetic resonance imaging (MRI). If the argument M is
-omitted, the phantom is of size NxN. When setting the keyword argument
-`highConstrast` to false, the CT version of the phantom is created. Otherwise,
-the high contrast MRI version is calculated.
-"""
-function shepp_logan(M,N; highContrast=true)
-  # Initially proposed in Shepp, Larry; B. F. Logan (1974).
-  # "The Fourier Reconstruction of a Head Section". IEEE Transactions on Nuclear Science. NS-21.
-
-  P = zeros(M,N)
-
-  x = range(-1, stop=1, length=M)'
-  y = range(1, stop=-1, length=N)
-
-  centerX = [0, 0, 0.22, -0.22, 0, 0, 0, -0.08, 0, 0.06]
-  centerY = [0, -0.0184, 0, 0, 0.35, 0.1, -0.1, -0.605, -0.605, -0.605]
-  majorAxis = [0.69, 0.6624, 0.11, 0.16, 0.21, 0.046, 0.046, 0.046, 0.023, 0.023]
-  minorAxis = [0.92, 0.874, 0.31, 0.41, 0.25, 0.046, 0.046, 0.023, 0.023, 0.046]
-  theta = [0, 0, -18.0, 18.0, 0, 0, 0, 0, 0, 0]
-
-  # original (CT) version of the phantom
-  grayLevel = [2, -0.98, -0.02, -0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
-
-  if(highContrast)
-    # high contrast (MRI) version of the phantom
-    grayLevel = [1, -0.8, -0.2, -0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
-  end
-
-  for l=1:length(theta)
-    P += grayLevel[l] * (
-           ( (cos(theta[l] / 360*2*pi) * (x .- centerX[l]) .+
-              sin(theta[l] / 360*2*pi) * (y .- centerY[l])) / majorAxis[l] ).^2 .+
-           ( (sin(theta[l] / 360*2*pi) * (x .- centerX[l]) .-
-              cos(theta[l] / 360*2*pi) * (y .- centerY[l])) / minorAxis[l] ).^2 .< 1 )
-  end
-
-  return P
-end
-
-shepp_logan(N;highContrast=true) = shepp_logan(N,N;highContrast=highContrast)
 
 """
 ```

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -381,7 +381,7 @@ function findlocalextrema(img::AbstractArray{T,N}, region::Union{Tuple{Int,Varar
     edgeoffset = CartesianIndex(map(!, edges))
     R0 = CartesianIndices(axes(img))
     R = _clippedinds(R0,edgeoffset)
-    rstp = oneunit(first(R0))
+    rstp = _oneunit(first(R0))
     Rinterior = _clippedinds(R0,rstp)
     iregion = CartesianIndex(ntuple(d->d∈region, Val(N)))
     Rregion = CartesianIndices(map((f,l)->f:l,(-iregion).I, iregion.I))
@@ -505,7 +505,7 @@ function div(p::AbstractArray{T,3}) where T
     inds = axes(p)[1:2]
     out = similar(p, inds)
     Router = CartesianIndices(inds)
-    rstp = oneunit(first(Router))
+    rstp = _oneunit(first(Router))
     Rinner = _clippedinds(Router,rstp)
     # Since most of the points are in the interior, compute them more quickly by avoiding branches
     for I in Rinner

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,7 @@
+if VERSION <= v"1.0.5"
+    # https://github.com/JuliaLang/julia/pull/29442
+    _oneunit(::CartesianIndex{N}) where {N} = _oneunit(CartesianIndex{N})
+    _oneunit(::Type{CartesianIndex{N}}) where {N} = CartesianIndex(ntuple(x -> 1, Val(N)))
+else
+    _oneunit = Base.oneunit
+end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1016,3 +1016,55 @@ function cliphist(hist::AbstractArray{T, 1}, clip::Number) where T
     end
     clipped_hist
 end
+
+# phantom images
+
+"""
+```
+phantom = shepp_logan(N,[M]; highContrast=true)
+```
+
+output the NxM Shepp-Logan phantom, which is a standard test image usually used
+for comparing image reconstruction algorithms in the field of computed
+tomography (CT) and magnetic resonance imaging (MRI). If the argument M is
+omitted, the phantom is of size NxN. When setting the keyword argument
+`highConstrast` to false, the CT version of the phantom is created. Otherwise,
+the high contrast MRI version is calculated.
+"""
+function shepp_logan(M,N; highContrast=true)
+  # Initially proposed in Shepp, Larry; B. F. Logan (1974).
+  # "The Fourier Reconstruction of a Head Section". IEEE Transactions on Nuclear Science. NS-21.
+
+  Base.depwarn("`shepp_logan` will be removed in a future release, please use `TestImages.shepp_logan` instead.", :shepp_logan)
+
+  P = zeros(M,N)
+
+  x = range(-1, stop=1, length=M)'
+  y = range(1, stop=-1, length=N)
+
+  centerX = [0, 0, 0.22, -0.22, 0, 0, 0, -0.08, 0, 0.06]
+  centerY = [0, -0.0184, 0, 0, 0.35, 0.1, -0.1, -0.605, -0.605, -0.605]
+  majorAxis = [0.69, 0.6624, 0.11, 0.16, 0.21, 0.046, 0.046, 0.046, 0.023, 0.023]
+  minorAxis = [0.92, 0.874, 0.31, 0.41, 0.25, 0.046, 0.046, 0.023, 0.023, 0.046]
+  theta = [0, 0, -18.0, 18.0, 0, 0, 0, 0, 0, 0]
+
+  # original (CT) version of the phantom
+  grayLevel = [2, -0.98, -0.02, -0.02, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+
+  if(highContrast)
+    # high contrast (MRI) version of the phantom
+    grayLevel = [1, -0.8, -0.2, -0.2, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]
+  end
+
+  for l=1:length(theta)
+    P += grayLevel[l] * (
+           ( (cos(theta[l] / 360*2*pi) * (x .- centerX[l]) .+
+              sin(theta[l] / 360*2*pi) * (y .- centerY[l])) / majorAxis[l] ).^2 .+
+           ( (sin(theta[l] / 360*2*pi) * (x .- centerX[l]) .-
+              cos(theta[l] / 360*2*pi) * (y .- centerY[l])) / minorAxis[l] ).^2 .< 1 )
+  end
+
+  return P
+end
+
+shepp_logan(N;highContrast=true) = shepp_logan(N,N;highContrast=highContrast)

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -433,7 +433,8 @@ using Test
         @test @inferred(component_centroids(lbltarget)) == Tuple[(1.5,2.5),(4/3,4/3),(5/3,11/3)]
     end
 
-    @testset "Phantoms" begin
+    # deprecated
+    @suppress_err @testset "Phantoms" begin
         P = [ 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0;
               0.0  0.0  1.0  0.2  0.2  1.0  0.0  0.0;
               0.0  0.0  0.2  0.3  0.3  0.2  0.0  0.0;
@@ -442,7 +443,7 @@ using Test
               0.0  0.0  0.2  0.2  0.2  0.2  0.0  0.0;
               0.0  0.0  1.0  0.2  0.2  1.0  0.0  0.0;
               0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0 ]
-        Q = shepp_logan(8)
+        Q = Images.shepp_logan(8)
         @test norm((P-Q)[:]) < 1e-10
         P = [ 0.0  0.0  0.0   0.0   0.0   0.0   0.0  0.0;
               0.0  0.0  2.0   1.02  1.02  2.0   0.0  0.0;
@@ -452,7 +453,7 @@ using Test
               0.0  0.0  1.02  1.02  1.02  1.02  0.0  0.0;
               0.0  0.0  2.0   1.02  1.02  2.0   0.0  0.0;
               0.0  0.0  0.0   0.0   0.0   0.0   0.0  0.0 ]
-        Q = shepp_logan(8, highContrast=false)
+        Q = Images.shepp_logan(8, highContrast=false)
         @test norm((P-Q)[:]) < 1e-10
     end
 
@@ -538,7 +539,8 @@ using Test
         @test sort(B)==sort(C)
     end
 
-    @testset "Thresholding" begin
+    # deprecated
+    @suppress_err @testset "Thresholding" begin
 
         #otsu_threshold
         img = testimage("cameraman")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,10 @@
 using Test
+using Suppressor
 
 @testset "Images" begin
 include("arrays.jl")
 include("algorithms.jl")
-include("exposure.jl")
+@suppress_err include("exposure.jl") # deprecated
 include("edge.jl")
 include("corner.jl")
 include("writemime.jl")


### PR DESCRIPTION
This PR actually consists of four independent changes (If needed, I could rebase it into four commits...)

* deprecate `Images.shepp_logan` in favor of `TestImages.shepp_logan`
* `one(::CartesianIndex)` -> `oneunit`
* suppress the noisy deprecation output; we only need to make sure it runs and test passes
* `QuartzImageIO` is removed as test dependency; it's more reliable to use only one IO backend

It's worth noting that there is a name conflict between `TestImages.shepp_logan` and `Images.shepp_logan`. The only solution to this that I can come up with is to reexport `TestImages.shepp_logan`.