### PR TITLE
Reexport the deprecated permuteddimsview

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -28,6 +28,9 @@ using SparseArrays: findnz
 
 using Reexport
 @reexport using ImageCore
+if isdefined(ImageCore, :permuteddimsview)
+    export permuteddimsview
+end
 if isdefined(ColorTypes, :XRGB) && isdefined(ColorTypes, :RGB1)
     Base.@deprecate_binding RGB1 XRGB
     Base.@deprecate_binding RGB4 RGBX

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -1,6 +1,6 @@
 using Images, OffsetArrays, TestImages
 using Statistics, Random, LinearAlgebra, FFTW
-using Test
+using Test, Suppressor
 
 @testset "Algorithms" begin
     @testset "Statistics" begin


### PR DESCRIPTION
Currently tests are failing; it turns out that deprecations aren't re-exported automatically. This does it manually.

The absence of reports about this does suggest that most people seem to have figured this out on their own, but it is a little troubling.