### PR TITLE
deprecate ColorizedArray in favor of MappedArray

### DIFF
--- a/src/labeledarrays.jl
+++ b/src/labeledarrays.jl
@@ -18,6 +18,8 @@ associated with that point's label.
 This computation is performed lazily, as to be suitable even for large arrays.
 """
 function ColorizedArray(intensity, label::IndirectArray{C,N}) where {C<:Colorant,N}
+    depwarn("`ColorizedArray(intensity, label)` is deprecated, use `mappedarray(*, intensity, label)` from `MappedArrays` instead", :ColorizedArray)
+
     axes(intensity) == axes(label) || throw(DimensionMismatch("intensity and label must have the same axes, got $(axes(intensity)) and $(axes(label))"))
     CI = typeof(zero(C)*zero(eltype(intensity)))
     ColorizedArray{CI,N,typeof(intensity),typeof(label)}(intensity, label)

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -1,21 +1,27 @@
-using Images, IndirectArrays, Test
+using Images, IndirectArrays, Test, Suppressor
+using Images.MappedArrays: mappedarray
 
 @testset "ColorizedArray" begin
     intensity = [0.1 0.3; 0.2 0.4]
     labels = IndirectArray([1 2; 2 1], [RGB(1,0,0), RGB(0,0,1)])
-    A = ColorizedArray(intensity, labels)
+    colorized_A = @suppress_err ColorizedArray(intensity, labels)
+    mapped_A = mappedarray(*, intensity, labels)
+    
     target = intensity .* labels
-    @test eltype(A) == RGB{Float64}
-    @test size(A) == (2,2)
-    @test axes(A) == (Base.OneTo(2), Base.OneTo(2))
-    for i = 1:4
-        @test A[i] === target[i]
-    end
-    for j = 1:2, i = 1:2
-        @test A[i,j] === target[i,j]
-    end
-    for (a,t) in zip(A, target)
-        @test a === t
+
+    for A in (colorized_A, mapped_A) 
+        @test eltype(A) == RGB{Float64}
+        @test size(A) == (2,2)
+        @test axes(A) == (Base.OneTo(2), Base.OneTo(2))
+        for i = 1:4
+            @test A[i] === target[i]
+        end
+        for j = 1:2, i = 1:2
+            @test A[i,j] === target[i,j]
+        end
+        for (a,t) in zip(A, target)
+            @test a === t
+        end
     end
 end
 


### PR DESCRIPTION
`MappedArray` provides a more generic version of `ColorizedArray` so I believe it is good to not maintain `ColorizedArray` anymore.

`LazyArray` also provides similar operation; `LazyArray(@~ @. I * indexed_img)`.

closes https://github.com/JuliaImages/juliaimages.github.io/issues/132