### PR TITLE
Remove __precompile__ check

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -1,5 +1,3 @@
-VERSION < v"0.7.0-beta2.199" && __precompile__()
-
 module Images
 
 import Base.Iterators.take


### PR DESCRIPTION
Minimum package version is 1.3 so this is no longer necessary as it is the default