### PR TITLE
Added stdfinite, a standard deviation equivilant to meanfinite

### DIFF
--- a/src/Images.jl
+++ b/src/Images.jl
@@ -183,6 +183,7 @@ export
     magnitude,
     magnitude_phase,
     meanfinite,
+    stdfinite,
     entropy,
     orientation,
     padarray,

--- a/src/algorithms.jl
+++ b/src/algorithms.jl
@@ -24,6 +24,18 @@ function _meanfinite(A::AbstractArray, ::Type{T}, region) where T<:AbstractFloat
 end
 _meanfinite(A::AbstractArray, ::Type, region) = mean(A, dims=region)  # non floating-point
 
+"""
+`S = stdfinite(img, region` calculates the standard deviation of values along the dimensions listed in `region`, ignoring any non-finite values.
+"""
+function stdfinite(img::AbstractArray, region)
+    mean = meanfinite(img, region)
+    l = sum(1 .- isnan.(img), dims=region)
+    img = (img .- mean).^2
+    img[isnan.(img)] .= 0
+    s = sum(img, dims=region)
+    (s ./ (l .- 1)).^0.5
+end
+
 using Base: check_reducedims, reducedim1, safe_tail
 using Base.Broadcast: newindex
 

--- a/test/algorithms.jl
+++ b/test/algorithms.jl
@@ -13,6 +13,14 @@ using Test, Suppressor
             @test green(s) ≈ std(Ac[2,:,:])
             @test blue(s) ≈ std(Ac[3,:,:])
         end
+
+        A=rand(3,4,5,6)
+        s=stdfinite(A,(2,3,4))
+        @test s≈std(A,dims=(2,3,4))
+        A=rand(5)
+        A[1]=NaN
+        s=stdfinite(A,1)
+        @test s[1]≈std(A[2:end])
     end
 
     @testset "Features" begin


### PR DESCRIPTION
I can't seem to find anything that has similar functionality to meanfinite but for standard deviations and so have written up what I've been using here. It calculated the standard deviation of values in an array along given dimensions and ignores any NaN values.

I have included some basic tests and it is passing the others.

Thanks!