### PR TITLE
Images v0.25.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Images"
 uuid = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
-version = "0.25.0"
+version = "0.25.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
Given https://github.com/JuliaImages/Images.jl/pull/993 has been merged it would be good to get a new patch release to free up the ecosystem for the new ImageIO version.

As an aside, I think we've tagged a couple of non-breaking releases as breaking releases for ImageIO.
I think the rationale we've had has been that it makes sense when adding new backends, but I think it's not strictly a breaking change and causes downstream noise (like this)
