### PR TITLE
Images v0.25.2: remove EllipsisNotation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Images"
 uuid = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
-version = "0.25.1"
+version = "0.25.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/Images.jl
+++ b/src/Images.jl
@@ -26,7 +26,6 @@ const is_little_endian = ENDIAN_BOM == 0x04030201 # CHECKME(johnnychen94): is th
 @reexport using ImageContrastAdjustment
 @reexport using ImageQualityIndexes
 @reexport using IntegralArrays
-@reexport using IntegralArrays.IntervalSets.EllipsisNotation
 @reexport using ImageSegmentation
 
 # Non-exported symbol bindings to ImageShow so that we can use, e.g., `Images.gif`


### PR DESCRIPTION
I realize that we don't need to load EllipsisNotation at all because IntegralArrays already does this:

https://github.com/JuliaImages/IntegralArrays.jl/blob/0f8bdfd7466504f789ee20935999598b79ca0e7e/src/IntegralArrays.jl#L7-L8

This is a bug fix for IntergralArrays v0.1.4, I've checked that this works for old IntergralArrays version v0.1.3. Fixes #1005.

Will merge and tag a new release once the test passes.